### PR TITLE
Add fallback for BMI or BMI2 instructions

### DIFF
--- a/.github/workflows/ci-mac
+++ b/.github/workflows/ci-mac
@@ -1,0 +1,13 @@
+name: CI-Mac
+on: [push]
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+    steps:
+      - name: install compilers etc
+        run: sudo apt install g++
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - run: make -j$(nproc) test no-BMI2=1
+      - run: make -j$(nproc) release no-BMI2=1
+      - run: make -j$(nproc) perft no-BMI2=1

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI-Ubuntu
 on: [push]
 jobs:
   build-and-test:

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,14 @@ ifneq ($(LIBS),)
 	LINK_FLAGS += $(shell pkg-config --libs $(LIBS))
 endif
 
+# BMI and BMI2 instruction set
+ifeq ($(no-BMI),)
+	COMPILE_FLAGS += -mbmi
+ifeq ($(no-BMI2),)
+	COMPILE_FLAGS += -mbmi2
+endif
+endif
+
 # Verbose option, to output compile and link commands
 export V := false
 export CMD_PREFIX := @

--- a/config.mk
+++ b/config.mk
@@ -10,7 +10,7 @@ MAINS_PATH = mains
 # Space-separated pkg-config libraries used by this project
 LIBS =
 # General compiler flags
-COMPILE_FLAGS = -std=c++17 -Wall -Wextra -g -mbmi -mbmi2 -O3
+COMPILE_FLAGS = -std=c++17 -Wall -Wextra -g -O3
 # Additional release-specific flags
 RCOMPILE_FLAGS = -D NDEBUG -DDOCTEST_CONFIG_DISABLE
 # Additional debug-specific flags

--- a/includes/attacks.hpp
+++ b/includes/attacks.hpp
@@ -2,6 +2,7 @@
 
 # include "bitboard.hpp"
 # include "lookup.hpp"
+# include "bmi2_fallback.hpp"
 
 # include <tuple>
 
@@ -150,14 +151,14 @@ constexpr BitMask compute_file_blocker(const size_t square){
 const auto file_blocker_lookup = lookup_table<BitMask, 64>(compute_file_blocker);
 
 inline BitMask rook_seen_rank(const Square square, const BitMask occ){
-	const BitMask ext_block_mask = _pext_u64(occ, rank_blocker_lookup[square]);
+	const BitMask ext_block_mask = PEXT(occ, rank_blocker_lookup[square]);
 	const BitMask ext_seen_mask = slider_attack_table[square % 8][ext_block_mask];
-	return _pdep_u64(ext_seen_mask, rank_lookup[square]);
+	return PDEP(ext_seen_mask, rank_lookup[square]);
 }
 inline BitMask rook_seen_file(const Square square, const BitMask occ){
-	const BitMask ext_block_mask = _pext_u64(occ, file_blocker_lookup[square]);
+	const BitMask ext_block_mask = PEXT(occ, file_blocker_lookup[square]);
 	const BitMask ext_seen_mask = slider_attack_table[square / 8][ext_block_mask];
-	return _pdep_u64(ext_seen_mask, file_lookup[square]);
+	return PDEP(ext_seen_mask, file_lookup[square]);
 }
 inline BitMask rook_seen(const Square square, const BitMask occ){
 	return rook_seen_rank(square, occ) | rook_seen_file(square, occ);
@@ -198,15 +199,15 @@ constexpr auto index_on_lower(Square square){
 }
 
 inline BitMask bishop_seen_upper(const Square square, const BitMask occ){
-	const BitMask ext_block_mask = _pext_u64(occ, upper_blocker_lookup[square]);
+	const BitMask ext_block_mask = PEXT(occ, upper_blocker_lookup[square]);
 	const BitMask ext_seen_mask = slider_attack_table[index_on_upper(square)][ext_block_mask];
-	return _pdep_u64(ext_seen_mask, upper_diag_lookup[square]);
+	return PDEP(ext_seen_mask, upper_diag_lookup[square]);
 }
 
 inline BitMask bishop_seen_lower(const Square square, const BitMask occ){
-	const BitMask ext_block_mask = _pext_u64(occ, lower_blocker_lookup[square]);
+	const BitMask ext_block_mask = PEXT(occ, lower_blocker_lookup[square]);
 	const BitMask ext_seen_mask = slider_attack_table[index_on_lower(square)][ext_block_mask];
-	return _pdep_u64(ext_seen_mask, lower_diag_lookup[square]);
+	return PDEP(ext_seen_mask, lower_diag_lookup[square]);
 }
 
 inline BitMask bishop_seen(const Square square, const BitMask occ){

--- a/includes/bitboard.hpp
+++ b/includes/bitboard.hpp
@@ -2,10 +2,11 @@
 
 # include <cstdint>
 # include <x86intrin.h>
+# include "bmi_fallback.hpp"
 
 #define SquareOf(X) _tzcnt_u64(X)
 #define ToMask(X) (1ull << (X))
-#define Bitloop(X, var) for(auto var = X; var; var = __blsr_u64(var))
+#define Bitloop(X, var) for(auto var = X; var; var = BLSR(var))
 #define Flip(X) ((X) ^ 56)
 #define FlipIf(cond, X) ((cond) ? ((X) ^ 56) : (X))
 

--- a/includes/bmi2_fallback.hpp
+++ b/includes/bmi2_fallback.hpp
@@ -1,0 +1,33 @@
+# pragma once
+
+# ifdef __BMI2__
+
+# include <x86intrin.h>
+# define PEXT _pext_u64
+# define PDEP _pdep_u64
+
+# else
+
+# include <cstdint>
+
+constexpr uint64_t PEXT(const uint64_t val, uint64_t mask) {
+  uint64_t res = 0;
+  for (uint64_t bb = 1; mask; bb += bb) {
+    if ( val & mask & -mask )
+      res |= bb;
+    mask &= mask - 1;
+  }
+  return res;
+}
+
+constexpr uint64_t PDEP(const uint64_t val, uint64_t mask) {
+  uint64_t res = 0;
+  for (uint64_t bb = 1; mask; bb += bb) {
+    if (val & bb)
+      res |= mask & -mask;
+    mask &= mask - 1;
+  }
+  return res;
+}
+
+# endif

--- a/includes/bmi_fallback.hpp
+++ b/includes/bmi_fallback.hpp
@@ -1,0 +1,13 @@
+# pragma once
+
+# ifdef __BMI__
+
+# include <x86intrin.h>
+# define BLSR __blsr_u64
+
+# else
+
+# include <cstdint>
+constexpr uint64_t BLSR(const uint64_t x){ return x & (x-1); }
+
+# endif

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -4,6 +4,7 @@
 # include "movegen.hpp"
 # include "parse_format.hpp"
 # include "attacks.hpp"
+# include "bmi2_fallback.hpp"
 
 /* KNIGHTS */
 
@@ -85,21 +86,21 @@ std::tuple<BitMask, BitMask> rook_checks_and_pins(
 	const BitMask rank = rank_lookup[king];
 	Bitloop(rank & rooks, loop_var){
 		const Square rook = SquareOf(loop_var);
-		const BitMask ext_block_mask = _pext_u64(occ, rank_blocker_lookup[king]);
+		const BitMask ext_block_mask = PEXT(occ, rank_blocker_lookup[king]);
 		BitMask check, pin;
 		std::tie(check, pin) = slider_cnp_table[rook % 8][king % 8][ext_block_mask];
-		h_check_mask |= _pdep_u64(check, rank);
-		hv_pin |= _pdep_u64(pin, rank);
+		h_check_mask |= PDEP(check, rank);
+		hv_pin |= PDEP(pin, rank);
 	}
 
 	const BitMask file = file_lookup[king];
 	Bitloop(file & rooks, loop_var){
 		const Square rook = SquareOf(loop_var);
-		const BitMask ext_block_mask = _pext_u64(occ, file_blocker_lookup[king]);
+		const BitMask ext_block_mask = PEXT(occ, file_blocker_lookup[king]);
 		BitMask check, pin;
 		std::tie(check, pin) = slider_cnp_table[rook / 8][king / 8][ext_block_mask];
-		v_check_mask |= _pdep_u64(check, file);
-		hv_pin |= _pdep_u64(pin, file);
+		v_check_mask |= PDEP(check, file);
+		hv_pin |= PDEP(pin, file);
 	}
 
 	BitMask check_mask = (h_check_mask ? h_check_mask : FULL_BOARD) &
@@ -142,25 +143,25 @@ std::tuple<BitMask, BitMask> bishop_checks_and_pins(
 	const BitMask upper_diag = upper_diag_lookup[king];
 	Bitloop(upper_diag & bishops, loop_var){
 		const Square bishop = SquareOf(loop_var);
-		const BitMask ext_block_mask = _pext_u64(occ, upper_blocker_lookup[king]);
+		const BitMask ext_block_mask = PEXT(occ, upper_blocker_lookup[king]);
 		const auto k_index = index_on_upper(king);
 		const auto b_index = index_on_upper(bishop);
 		BitMask check, pin;
 		std::tie(check, pin) = slider_cnp_table[b_index][k_index][ext_block_mask];
-		check_mask |= _pdep_u64(check, upper_diag);
-		diag_pin |= _pdep_u64(pin, upper_diag);
+		check_mask |= PDEP(check, upper_diag);
+		diag_pin |= PDEP(pin, upper_diag);
 	}
 
 	const BitMask lower_diag = lower_diag_lookup[king];
 	Bitloop(lower_diag & bishops, loop_var){
 		const Square bishop = SquareOf(loop_var);
-		const BitMask ext_block_mask = _pext_u64(occ, lower_blocker_lookup[king]);
+		const BitMask ext_block_mask = PEXT(occ, lower_blocker_lookup[king]);
 		const auto k_index = index_on_lower(king);
 		const auto b_index = index_on_lower(bishop);
 		BitMask check, pin;
 		std::tie(check, pin) = slider_cnp_table[b_index][k_index][ext_block_mask];
-		check_mask |= _pdep_u64(check, lower_diag);
-		diag_pin |= _pdep_u64(pin, lower_diag);
+		check_mask |= PDEP(check, lower_diag);
+		diag_pin |= PDEP(pin, lower_diag);
 	}
 
 	return std::make_tuple(check_mask ? check_mask : FULL_BOARD, diag_pin);


### PR DESCRIPTION
I benchmarked this by searching to depth 12 from the starting position. The build without BMI/BMI2 took over 50% longer (1392ms vs 2101ms).

Without BMI/BMI2:
```
debug on
position startpos
go depth 12
info depth 1 time 0 nodes 9 pv d2d4 score cp 50
info depth 2 time 0 nodes 47 pv d2d4 d7d5 score cp 4
info depth 3 time 1 nodes 215 pv d2d4 d7d5 g1f3 score cp 32
info depth 4 time 2 nodes 971 pv d2d4 d7d5 g1f3 g8f6 score cp 4
info depth 5 time 5 nodes 2527 pv d2d4 d7d5 g1f3 g8f6 b1c3 score cp 23
info depth 6 time 13 nodes 9524 pv d2d4 d7d5 g1f3 g8f6 b1c3 b8c6 score cp 4
info depth 7 time 28 nodes 25088 pv g1f3 d7d5 e2e3 c8f5 f1d3 f5d3 c2d3 score cp 27
info depth 8 time 88 nodes 96415 pv e2e4 b8c6 d2d4 e7e6 g1f3 d7d5 b1c3 g8f6 score cp 17
info depth 9 time 177 nodes 221525 pv e2e4 e7e6 d2d4 d7d5 b1c3 g8f6 e4e5 f6e4 g1f3 score cp 24
info depth 10 time 326 nodes 435973 pv e2e4 e7e6 d2d4 d7d5 b1c3 b8c6 g1f3 g8f6 e4e5 f6g4 score cp 22
info depth 11 time 871 nodes 1159341 pv e2e4 e7e5 b1c3 g8f6 g1f3 f8c5 f3e5 c5d4 e5f3 b8c6 d2d3 score cp 30
info depth 12 time 2101 nodes 2790674 pv e2e4 e7e6 g1f3 d7d5 e4d5 e6d5 f1d3 c7c5 e1g1 c5c4 f1e1 f8e7 d3e2 score cp 15
bestmove e2e4
quit
```

With BMI/BMI2:
```
debug on
position startpos
go depth 12
info depth 1 time 0 nodes 9 pv d2d4 score cp 50
info depth 2 time 0 nodes 47 pv d2d4 d7d5 score cp 4
info depth 3 time 0 nodes 215 pv d2d4 d7d5 g1f3 score cp 32
info depth 4 time 2 nodes 971 pv d2d4 d7d5 g1f3 g8f6 score cp 4
info depth 5 time 4 nodes 2527 pv d2d4 d7d5 g1f3 g8f6 b1c3 score cp 23
info depth 6 time 10 nodes 9524 pv d2d4 d7d5 g1f3 g8f6 b1c3 b8c6 score cp 4
info depth 7 time 23 nodes 25088 pv g1f3 d7d5 e2e3 c8f5 f1d3 f5d3 c2d3 score cp 27
info depth 8 time 69 nodes 96415 pv e2e4 b8c6 d2d4 e7e6 g1f3 d7d5 b1c3 g8f6 score cp 17
info depth 9 time 137 nodes 221525 pv e2e4 e7e6 d2d4 d7d5 b1c3 g8f6 e4e5 f6e4 g1f3 score cp 24
info depth 10 time 244 nodes 435973 pv e2e4 e7e6 d2d4 d7d5 b1c3 b8c6 g1f3 g8f6 e4e5 f6g4 score cp 22
info depth 11 time 596 nodes 1159341 pv e2e4 e7e5 b1c3 g8f6 g1f3 f8c5 f3e5 c5d4 e5f3 b8c6 d2d3 score cp 30
info depth 12 time 1392 nodes 2790674 pv e2e4 e7e6 g1f3 d7d5 e4d5 e6d5 f1d3 c7c5 e1g1 c5c4 f1e1 f8e7 d3e2 score cp 15
bestmove e2e4
quit
```