### PR TITLE
Replace priority queue with moves with a heap array

### DIFF
--- a/includes/move_queue.hpp
+++ b/includes/move_queue.hpp
@@ -1,8 +1,11 @@
 # pragma once
 
 # include <tuple>
-# include <queue>
+# include <array>
 # include "board.hpp"
+
+// Theoretical upper bound is 218, but maximum ever seen in a serious game is 79
+const size_t move_array_max_size = 128;
 
 struct ABCMask{
 	BitMask A;
@@ -10,37 +13,57 @@ struct ABCMask{
 	BitMask C;
 };
 
+ABCMask abc_for_halfboard(const HalfBoard &side);
 
-template <bool white>
 struct MoveQueue{
-	MoveQueue(const Board &board);
-	MoveQueue(const Board &board, const Move hint, const Move killer1, const Move killer2);
+	MoveQueue(const bool white, const Board &board, const Move hint, const Move killer1, const Move killer2) :
+		Hint(hint), Killer1(killer1), Killer2(killer2), EnemyABC(abc_for_halfboard(white ? board.Black : board.White)),
+		EnemyAtk(white ? board.BkAtk : board.WtAtk) { }
+	MoveQueue(const bool white, const Board &board) : EnemyABC(abc_for_halfboard(white ? board.Black : board.White)),
+			EnemyAtk(white ? board.BkAtk : board.WtAtk){ }
 
 	bool empty() const;
 	Move top() const;
 	int top_prio() const;
 	void pop();
+	void heapify();
 
+	template <bool white>
 	void push_knight_move(const Square from, const Square to);
+	template <bool white>
 	void push_bishop_move(const Square from, const Square to);
+	template <bool white>
 	void push_rook_move(const Square from, const Square to);
+	template <bool white>
 	void push_queen_move(const Square from, const Square to);
+	template <bool white>
 	void push_king_move(const Square from, const Square to);
+	template <bool white>
 	void push_castle_qs();
+	template <bool white>
 	void push_castle_ks();
+	template <bool white>
 	void push_single_pawn_move(const Square from);
+	template <bool white>
 	void push_double_pawn_move(const Square from);
+	template <bool white>
 	void push_pawn_capture_left(const Square from);
+	template <bool white>
 	void push_pawn_capture_right(const Square from);
+	template <bool white>
 	void push_ep_capture_left(const Square from);
+	template <bool white>
 	void push_ep_capture_right(const Square from);
 
 	private:
-		std::priority_queue<std::tuple<int, Move>> Queue;
-		const Move Hint;
-		const Move Killer1;
-		const Move Killer2;
+		std::array<std::tuple<int, Move>, move_array_max_size> move_array;
+		size_t queue_length = 0;
+		const Move Hint = 0;
+		const Move Killer1 = 0;
+		const Move Killer2 = 0;
 		const ABCMask EnemyABC;
 		const Attacks &EnemyAtk;
 
+		inline void handle_promotions(const Square from, const Square to, const int freq);
+		inline void push_move_helper(int priority, const Move move);
 };

--- a/includes/movegen.hpp
+++ b/includes/movegen.hpp
@@ -17,7 +17,7 @@ template <bool white>
 ChecksAndPins checks_and_pins(const Board &board);
 
 template <bool white>
-MoveQueue<white> generate_moves(const Board &board, const ChecksAndPins cnp, const Move hint, const Move killer1, const Move killer2);
+MoveQueue generate_moves(const Board &board, const ChecksAndPins cnp, const Move hint, const Move killer1, const Move killer2);
 
 template <bool white>
-MoveQueue<white> generate_forcing(const Board &board, const ChecksAndPins cnp);
+MoveQueue generate_forcing(const Board &board, const ChecksAndPins cnp);

--- a/src/move_queue.cpp
+++ b/src/move_queue.cpp
@@ -1,5 +1,5 @@
 # include <algorithm>
-# include <exception>
+# include <stdexcept>
 # include "move_queue.hpp"
 
 # ifdef TUNE_MOVE_ORDER

--- a/src/move_queue.cpp
+++ b/src/move_queue.cpp
@@ -315,34 +315,34 @@ void MoveQueue::push_knight_move(const Square from, const Square to){
 	const Move move = move_from_squares(from, to, KNIGHT_MOVE);
 	const int base_prio = knight_freq[FlipIf(white, to)] + knight_capture_freq[piece_at_square(to, EnemyABC)]
 		- knight_fear_penalty(to, EnemyAtk) + knight_evade_bonus(from, EnemyAtk);
-	push_move_helper(move, base_prio);
+	push_move_helper(base_prio, move);
 }
 template <bool white>
 void MoveQueue::push_bishop_move(const Square from, const Square to){
 	const Move move = move_from_squares(from, to, BISHOP_MOVE);
 	const int base_prio = bishop_freq[FlipIf(white, to)] + bishop_capture_freq[piece_at_square(to, EnemyABC)]
 		- bishop_fear_penalty(to, EnemyAtk) + bishop_evade_bonus(from, EnemyAtk);
-	push_move_helper(move, base_prio);
+	push_move_helper(base_prio, move);
 }
 template <bool white>
 void MoveQueue::push_rook_move(const Square from, const Square to){
 	const Move move = move_from_squares(from, to, ROOK_MOVE);
 	const int base_prio = rook_freq[FlipIf(white, to)] + rook_capture_freq[piece_at_square(to, EnemyABC)]
 		- rook_fear_penalty(to, EnemyAtk) + rook_evade_bonus(from, EnemyAtk);
-	push_move_helper(move, base_prio);
+	push_move_helper(base_prio, move);
 }
 template <bool white>
 void MoveQueue::push_queen_move(const Square from, const Square to){
 	const Move move = move_from_squares(from, to, QUEEN_MOVE);
 	const int base_prio = queen_freq[FlipIf(white, to)] + queen_capture_freq[piece_at_square(to, EnemyABC)]
 		- queen_fear_penalty(to, EnemyAtk) + queen_evade_bonus(from, EnemyAtk);
-	push_move_helper(move, base_prio);
+	push_move_helper(base_prio, move);
 }
 template <bool white>
 void MoveQueue::push_king_move(const Square from, const Square to){
 	const Move move = move_from_squares(from, to, KING_MOVE);
 	const int base_prio = king_freq[FlipIf(white, to)] + king_capture_freq[piece_at_square(to, EnemyABC)];
-	push_move_helper(move, base_prio);
+	push_move_helper(base_prio, move);
 }
 template <bool white>
 void MoveQueue::push_castle_qs(){

--- a/src/move_queue.cpp
+++ b/src/move_queue.cpp
@@ -1,4 +1,5 @@
 # include <algorithm>
+# include <exception>
 # include "move_queue.hpp"
 
 # ifdef TUNE_MOVE_ORDER

--- a/src/move_queue.cpp
+++ b/src/move_queue.cpp
@@ -1,8 +1,5 @@
-# include <tuple>
-# include <queue>
-# include "board.hpp"
-# include "pst.hpp"
-# include "eval.hpp"
+# include <algorithm>
+# include "move_queue.hpp"
 
 # ifdef TUNE_MOVE_ORDER
 # include "register_params.hpp"
@@ -171,245 +168,270 @@ MOVE_ORDER_PARAM(underpromote_to_knight_freq, -450)
 MOVE_ORDER_PARAM(underpromote_to_bishop_freq, -638)
 MOVE_ORDER_PARAM(underpromote_to_rook_freq, -536)
 
-
-struct ABCMask{
-	BitMask A;
-	BitMask B;
-	BitMask C;
-};
-
 ABCMask abc_for_halfboard(const HalfBoard &side){
 	return ABCMask{side.Rook | side.Queen, side.Knight | side.Bishop, side.Pawn | side.Bishop | side.Queen};
 }
 
+bool MoveQueue::empty() const{ return queue_length == 0; }
+Move MoveQueue::top() const{ return std::get<1>(move_array[0]); }
+int MoveQueue::top_prio() const{ return std::get<0>(move_array[0]); }
+void MoveQueue::pop(){
+	std::pop_heap(move_array.data(), move_array.data() + queue_length);
+	queue_length--;
+}
+void MoveQueue::heapify(){ std::make_heap(move_array.data(), move_array.data() + queue_length); }
+
+constexpr int piece_at_square(const Square to, const ABCMask abc){
+	const BitMask mask = ToMask(to);
+	return ((abc.A & mask) ? 4 : 0) + ((abc.B & mask) ? 2 : 0) + ((abc.C & mask) ? 1 : 0);
+}
+
+constexpr int pawn_fear_penalty(const Square to, const Attacks& atk){
+	const BitMask mask = ToMask(to);
+	if (atk.Pawn & mask) return pawn_fear_pawn;
+	if (atk.Knight & mask) return pawn_fear_knight;
+	if (atk.King & mask) return pawn_fear_king;
+	if (atk.Rook & mask) return pawn_fear_rook;
+	if (atk.Bishop & mask) return pawn_fear_bishop;
+	if (atk.Queen & mask) return pawn_fear_queen;
+	return 0;
+}
+constexpr int knight_fear_penalty(const Square to, const Attacks& atk){
+	const BitMask mask = ToMask(to);
+	if (atk.Pawn & mask) return knight_fear_pawn;
+	if (atk.King & mask) return knight_fear_king;
+	if (atk.Bishop & mask) return knight_fear_bishop;
+	if (atk.Rook & mask) return knight_fear_rook;
+	if (atk.Knight & mask) return knight_fear_knight;
+	if (atk.Queen & mask) return knight_fear_queen;
+	return 0;
+}
+constexpr int bishop_fear_penalty(const Square to, const Attacks& atk){
+	const BitMask mask = ToMask(to);
+	if (atk.Pawn & mask) return bishop_fear_pawn;
+	if (atk.Knight & mask) return bishop_fear_knight;
+	if (atk.King & mask) return bishop_fear_king;
+	if (atk.Rook & mask) return bishop_fear_rook;
+	if (atk.Bishop & mask) return bishop_fear_bishop;
+	if (atk.Queen & mask) return bishop_fear_queen;
+	return 0;
+}
+constexpr int rook_fear_penalty(const Square to, const Attacks& atk){
+	const BitMask mask = ToMask(to);
+	if (atk.Pawn & mask) return rook_fear_pawn;
+	if (atk.Knight & mask) return rook_fear_knight;
+	if (atk.Bishop & mask) return rook_fear_bishop;
+	if (atk.Rook & mask) return rook_fear_rook;
+	if (atk.King & mask) return rook_fear_king;
+	if (atk.Queen & mask) return rook_fear_queen;
+	return 0;
+}
+constexpr int queen_fear_penalty(const Square to, const Attacks& atk){
+	const BitMask mask = ToMask(to);
+	if (atk.Pawn & mask) return queen_fear_pawn;
+	if (atk.Knight & mask) return queen_fear_knight;
+	if (atk.Bishop & mask) return queen_fear_bishop;
+	if (atk.Rook & mask) return queen_fear_rook;
+	if (atk.Queen & mask) return queen_fear_queen;
+	if (atk.King & mask) return queen_fear_king;
+	return 0;
+}
+
+constexpr int pawn_evade_bonus(const Square to, const Attacks& atk){
+	const BitMask mask = ToMask(to);
+	if (atk.Pawn & mask) return pawn_evade_pawn;
+	if (atk.Knight & mask) return pawn_evade_knight;
+	if (atk.King & mask) return pawn_evade_king;
+	if (atk.Rook & mask) return pawn_evade_rook;
+	if (atk.Bishop & mask) return pawn_evade_bishop;
+	if (atk.Queen & mask) return pawn_evade_queen;
+	return 0;
+}
+constexpr int knight_evade_bonus(const Square to, const Attacks& atk){
+	const BitMask mask = ToMask(to);
+	if (atk.Pawn & mask) return knight_evade_pawn;
+	if (atk.King & mask) return knight_evade_king;
+	if (atk.Bishop & mask) return knight_evade_bishop;
+	if (atk.Rook & mask) return knight_evade_rook;
+	if (atk.Knight & mask) return knight_evade_knight;
+	if (atk.Queen & mask) return knight_evade_queen;
+	return 0;
+}
+constexpr int bishop_evade_bonus(const Square to, const Attacks& atk){
+	const BitMask mask = ToMask(to);
+	if (atk.Pawn & mask) return bishop_evade_pawn;
+	if (atk.Knight & mask) return bishop_evade_knight;
+	if (atk.King & mask) return bishop_evade_king;
+	if (atk.Rook & mask) return bishop_evade_rook;
+	if (atk.Bishop & mask) return bishop_evade_bishop;
+	if (atk.Queen & mask) return bishop_evade_queen;
+	return 0;
+}
+constexpr int rook_evade_bonus(const Square to, const Attacks& atk){
+	const BitMask mask = ToMask(to);
+	if (atk.Pawn & mask) return rook_evade_pawn;
+	if (atk.Knight & mask) return rook_evade_knight;
+	if (atk.Bishop & mask) return rook_evade_bishop;
+	if (atk.Rook & mask) return rook_evade_rook;
+	if (atk.King & mask) return rook_evade_king;
+	if (atk.Queen & mask) return rook_evade_queen;
+	return 0;
+}
+constexpr int queen_evade_bonus(const Square to, const Attacks& atk){
+	const BitMask mask = ToMask(to);
+	if (atk.Pawn & mask) return queen_evade_pawn;
+	if (atk.Knight & mask) return queen_evade_knight;
+	if (atk.Bishop & mask) return queen_evade_bishop;
+	if (atk.Rook & mask) return queen_evade_rook;
+	if (atk.Queen & mask) return queen_evade_queen;
+	return 0;
+}
+
+inline void MoveQueue::push_move_helper(int priority, const Move move){
+	if (queue_length >= move_array_max_size) {
+		throw std::runtime_error("Move array full!");
+	}
+
+	if (move == Hint) priority += 100000;
+	if (move == Killer1) priority += 100;
+	if (move == Killer2) priority += 100;
+	
+	move_array[queue_length] = std::make_tuple(priority, move);
+	queue_length++;
+}
+inline void MoveQueue::handle_promotions(const Square from, const Square to, const int freq){
+	const Move n = move_from_squares(from, to, PROMOTE_TO_KNIGHT);
+	push_move_helper(freq + underpromote_to_knight_freq, n);
+	const Move b = move_from_squares(from, to, PROMOTE_TO_BISHOP);
+	push_move_helper(freq + underpromote_to_bishop_freq, b);
+	const Move r = move_from_squares(from, to, PROMOTE_TO_ROOK);
+	push_move_helper(freq + underpromote_to_rook_freq, r);
+	const Move q = move_from_squares(from, to, PROMOTE_TO_QUEEN);
+	push_move_helper(freq, q);
+}
 
 template <bool white>
-struct MoveQueue{
-	MoveQueue(const Board &board, const Move hint, const Move killer1, const Move killer2) :
-		Hint(hint), Killer1(killer1), Killer2(killer2), EnemyABC(abc_for_halfboard(get_side<not white>(board))),
-		EnemyAtk(white ? board.BkAtk : board.WtAtk) { }
-	MoveQueue(const Board &board) : Hint(0), Killer1(0), Killer2(0), EnemyABC(abc_for_halfboard(get_side<not white>(board))),
-			EnemyAtk(white ? board.BkAtk : board.WtAtk){ }
+void MoveQueue::push_knight_move(const Square from, const Square to){
+	const Move move = move_from_squares(from, to, KNIGHT_MOVE);
+	const int base_prio = knight_freq[FlipIf(white, to)] + knight_capture_freq[piece_at_square(to, EnemyABC)]
+		- knight_fear_penalty(to, EnemyAtk) + knight_evade_bonus(from, EnemyAtk);
+	push_move_helper(move, base_prio);
+}
+template <bool white>
+void MoveQueue::push_bishop_move(const Square from, const Square to){
+	const Move move = move_from_squares(from, to, BISHOP_MOVE);
+	const int base_prio = bishop_freq[FlipIf(white, to)] + bishop_capture_freq[piece_at_square(to, EnemyABC)]
+		- bishop_fear_penalty(to, EnemyAtk) + bishop_evade_bonus(from, EnemyAtk);
+	push_move_helper(move, base_prio);
+}
+template <bool white>
+void MoveQueue::push_rook_move(const Square from, const Square to){
+	const Move move = move_from_squares(from, to, ROOK_MOVE);
+	const int base_prio = rook_freq[FlipIf(white, to)] + rook_capture_freq[piece_at_square(to, EnemyABC)]
+		- rook_fear_penalty(to, EnemyAtk) + rook_evade_bonus(from, EnemyAtk);
+	push_move_helper(move, base_prio);
+}
+template <bool white>
+void MoveQueue::push_queen_move(const Square from, const Square to){
+	const Move move = move_from_squares(from, to, QUEEN_MOVE);
+	const int base_prio = queen_freq[FlipIf(white, to)] + queen_capture_freq[piece_at_square(to, EnemyABC)]
+		- queen_fear_penalty(to, EnemyAtk) + queen_evade_bonus(from, EnemyAtk);
+	push_move_helper(move, base_prio);
+}
+template <bool white>
+void MoveQueue::push_king_move(const Square from, const Square to){
+	const Move move = move_from_squares(from, to, KING_MOVE);
+	const int base_prio = king_freq[FlipIf(white, to)] + king_capture_freq[piece_at_square(to, EnemyABC)];
+	push_move_helper(move, base_prio);
+}
+template <bool white>
+void MoveQueue::push_castle_qs(){
+	const Move move = move_from_squares(FlipIf(white, E8), FlipIf(white, C8), CASTLE_QUEENSIDE);
+	push_move_helper(castle_qs_freq, move);
+}
+template <bool white>
+void MoveQueue::push_castle_ks(){
+	const Move move = move_from_squares(FlipIf(white, E8), FlipIf(white, G8), CASTLE_KINGSIDE);
+	push_move_helper(castle_ks_freq, move);
+}
+template <bool white>
+void MoveQueue::push_single_pawn_move(const Square from){
+	const Square to = white ? (from + 8) : (from - 8);
+	const int freq = pawn_freq[FlipIf(white, to)] - pawn_fear_penalty(to, EnemyAtk) + pawn_evade_bonus(from, EnemyAtk);
+	if (white ? (to >= A8) : (to <= H1)) {
+		handle_promotions(from, to, freq);
+	} else {
+		const Move move = move_from_squares(from, to, SINGLE_PAWN_PUSH);
+		push_move_helper(freq, move);
+	}
+}
+template <bool white>
+void MoveQueue::push_double_pawn_move(const Square from){
+	const Square to = white ? (from + 16) : (from - 16);
+	const Move move = move_from_squares(from, to, DOUBLE_PAWN_PUSH);
+	const int move_prio = pawn_freq[FlipIf(white, to)] - pawn_fear_penalty(to, EnemyAtk) + pawn_evade_bonus(from, EnemyAtk);
+	push_move_helper(move_prio, move);
+}
+template <bool white>
+void MoveQueue::push_pawn_capture_left(const Square from){
+	const Square to = white ? (from + 7) : (from - 7);
+	const int freq = pawn_freq[FlipIf(white, to)] + pawn_capture_freq[piece_at_square(to, EnemyABC)] 
+		- pawn_fear_penalty(to, EnemyAtk) + pawn_evade_bonus(from, EnemyAtk);
+	if (white ? (to >= A8) : (to <= H1)) {
+		handle_promotions(from, to, freq);
+	} else {
+		const Move move = move_from_squares(from, to, PAWN_CAPTURE);
+		push_move_helper(freq, move);
+	}
+}
+template <bool white>
+void MoveQueue::push_pawn_capture_right(const Square from){
+	const Square to = white ? (from + 9) : (from - 9);
+	const int freq = pawn_freq[FlipIf(white, to)] + pawn_capture_freq[piece_at_square(to, EnemyABC)] 
+		- pawn_fear_penalty(to, EnemyAtk) + pawn_evade_bonus(from, EnemyAtk);
+	if (white ? (to >= A8) : (to <= H1)) {
+		handle_promotions(from, to, freq);
+	} else {
+		const Move move = move_from_squares(from, to, PAWN_CAPTURE);
+		push_move_helper(freq, move);
+	}
+}
+template <bool white>
+void MoveQueue::push_ep_capture_left(const Square from){
+	const Square to = white ? (from + 7) : (from - 7);
+	const Move move = move_from_squares(from, to, EN_PASSANT_CAPTURE);
+	push_move_helper(en_passant_freq, move);
+}
+template <bool white>
+void MoveQueue::push_ep_capture_right(const Square from){
+	const Square to = white ? (from + 9) : (from - 9);
+	const Move move = move_from_squares(from, to, EN_PASSANT_CAPTURE);
+	push_move_helper(en_passant_freq, move);
+}
 
-	bool empty() const{ return Queue.empty(); }
-	Move top() const{ return std::get<1>(Queue.top()); }
-	int top_prio() const{ return std::get<0>(Queue.top()); }
-	void pop(){ Queue.pop(); }
-
-	void push_knight_move(const Square from, const Square to){
-		const Move move = move_from_squares(from, to, KNIGHT_MOVE);
-		Queue.push(std::make_tuple(knight_freq[FlipIf(white, to)] + knight_capture_freq[piece_at_square(to)]
-			- knight_fear_penalty(to) + knight_evade_bonus(from) + match_bonus(move), move));
-	}
-	void push_bishop_move(const Square from, const Square to){
-		const Move move = move_from_squares(from, to, BISHOP_MOVE);
-		Queue.push(std::make_tuple(bishop_freq[FlipIf(white, to)] + bishop_capture_freq[piece_at_square(to)]
-			- bishop_fear_penalty(to) + bishop_evade_bonus(from) + match_bonus(move), move));
-	}
-	void push_rook_move(const Square from, const Square to){
-		const Move move = move_from_squares(from, to, ROOK_MOVE);
-		Queue.push(std::make_tuple(rook_freq[FlipIf(white, to)] + rook_capture_freq[piece_at_square(to)]
-			- rook_fear_penalty(to) + rook_evade_bonus(from) + match_bonus(move), move));
-	}
-	void push_queen_move(const Square from, const Square to){
-		const Move move = move_from_squares(from, to, QUEEN_MOVE);
-		Queue.push(std::make_tuple(queen_freq[FlipIf(white, to)] + queen_capture_freq[piece_at_square(to)]
-			- queen_fear_penalty(to) + queen_evade_bonus(from) + match_bonus(move), move));
-	}
-	void push_king_move(const Square from, const Square to){
-		const Move move = move_from_squares(from, to, KING_MOVE);
-		Queue.push(std::make_tuple(king_freq[FlipIf(white, to)] + king_capture_freq[piece_at_square(to)] + 
-			match_bonus(move), move));
-	}
-	void push_castle_qs(){
-		const Move move = move_from_squares(FlipIf(white, E8), FlipIf(white, C8), CASTLE_QUEENSIDE);
-		Queue.push(std::make_tuple(castle_qs_freq + match_bonus(move), move));
-	}
-	void push_castle_ks(){
-		const Move move = move_from_squares(FlipIf(white, E8), FlipIf(white, G8), CASTLE_KINGSIDE);
-		Queue.push(std::make_tuple(castle_ks_freq + match_bonus(move), move));
-	}
-	void push_single_pawn_move(const Square from){
-		const Square to = white ? (from + 8) : (from - 8);
-		const int freq = pawn_freq[FlipIf(white, to)] - pawn_fear_penalty(to) + pawn_evade_bonus(from);
-		if (white ? (to >= A8) : (to <= H1)) {
-			handle_promotions(from, to, freq);
-		} else {
-			const Move move = move_from_squares(from, to, SINGLE_PAWN_PUSH);
-			Queue.push(std::make_tuple(freq + match_bonus(move), move));
-		}
-	}
-	void push_double_pawn_move(const Square from){
-		const Square to = white ? (from + 16) : (from - 16);
-		const Move move = move_from_squares(from, to, DOUBLE_PAWN_PUSH);
-		Queue.push(std::make_tuple(pawn_freq[FlipIf(white, to)] - pawn_fear_penalty(to) + pawn_evade_bonus(from)
-			+ match_bonus(move), move));
-	}
-	void push_pawn_capture_left(const Square from){
-		const Square to = white ? (from + 7) : (from - 7);
-		const int freq = pawn_freq[FlipIf(white, to)] + pawn_capture_freq[piece_at_square(to)] - pawn_fear_penalty(to)
-			+ pawn_evade_bonus(from);
-		if (white ? (to >= A8) : (to <= H1)) {
-			handle_promotions(from, to, freq);
-		} else {
-			const Move move = move_from_squares(from, to, PAWN_CAPTURE);
-			Queue.push(std::make_tuple(freq + match_bonus(move), move));
-		}
-	}
-	void push_pawn_capture_right(const Square from){
-		const Square to = white ? (from + 9) : (from - 9);
-		const int freq = pawn_freq[FlipIf(white, to)] + pawn_capture_freq[piece_at_square(to)] - pawn_fear_penalty(to)
-			+ pawn_evade_bonus(from);
-		if (white ? (to >= A8) : (to <= H1)) {
-			handle_promotions(from, to, freq);
-		} else {
-			const Move move = move_from_squares(from, to, PAWN_CAPTURE);
-			Queue.push(std::make_tuple(freq + match_bonus(move), move));
-		}
-	}
-	void push_ep_capture_left(const Square from){
-		const Square to = white ? (from + 7) : (from - 7);
-		const Move move = move_from_squares(from, to, EN_PASSANT_CAPTURE);
-		Queue.push(std::make_tuple(en_passant_freq + match_bonus(move), move));
-	}
-	void push_ep_capture_right(const Square from){
-		const Square to = white ? (from + 9) : (from - 9);
-		const Move move = move_from_squares(from, to, EN_PASSANT_CAPTURE);
-		Queue.push(std::make_tuple(en_passant_freq + match_bonus(move), move));
-	}
-
-	private:
-		std::priority_queue<std::tuple<int, Move>> Queue;
-		const Move Hint;
-		const Move Killer1;
-		const Move Killer2;
-		const ABCMask EnemyABC;
-		const Attacks& EnemyAtk;
-
-		constexpr int match_bonus(const Move move){
-			if (move == Hint) return 100000;
-			if (move == Killer1) return 100;
-			if (move == Killer2) return 100;
-			return 0;
-		}
-
-		constexpr int piece_at_square(const Square to){
-			const BitMask mask = ToMask(to);
-			return ((EnemyABC.A & mask) ? 4 : 0) + ((EnemyABC.B & mask) ? 2 : 0) + ((EnemyABC.C & mask) ? 1 : 0);
-		}
-
-		constexpr int pawn_fear_penalty(const Square to){
-			const BitMask mask = ToMask(to);
-			if (EnemyAtk.Pawn & mask) return pawn_fear_pawn;
-			if (EnemyAtk.Knight & mask) return pawn_fear_knight;
-			if (EnemyAtk.King & mask) return pawn_fear_king;
-			if (EnemyAtk.Rook & mask) return pawn_fear_rook;
-			if (EnemyAtk.Bishop & mask) return pawn_fear_bishop;
-			if (EnemyAtk.Queen & mask) return pawn_fear_queen;
-			return 0;
-		}
-		constexpr int knight_fear_penalty(const Square to){
-			const BitMask mask = ToMask(to);
-			if (EnemyAtk.Pawn & mask) return knight_fear_pawn;
-			if (EnemyAtk.King & mask) return knight_fear_king;
-			if (EnemyAtk.Bishop & mask) return knight_fear_bishop;
-			if (EnemyAtk.Rook & mask) return knight_fear_rook;
-			if (EnemyAtk.Knight & mask) return knight_fear_knight;
-			if (EnemyAtk.Queen & mask) return knight_fear_queen;
-			return 0;
-		}
-		constexpr int bishop_fear_penalty(const Square to){
-			const BitMask mask = ToMask(to);
-			if (EnemyAtk.Pawn & mask) return bishop_fear_pawn;
-			if (EnemyAtk.Knight & mask) return bishop_fear_knight;
-			if (EnemyAtk.King & mask) return bishop_fear_king;
-			if (EnemyAtk.Rook & mask) return bishop_fear_rook;
-			if (EnemyAtk.Bishop & mask) return bishop_fear_bishop;
-			if (EnemyAtk.Queen & mask) return bishop_fear_queen;
-			return 0;
-		}
-		constexpr int rook_fear_penalty(const Square to){
-			const BitMask mask = ToMask(to);
-			if (EnemyAtk.Pawn & mask) return rook_fear_pawn;
-			if (EnemyAtk.Knight & mask) return rook_fear_knight;
-			if (EnemyAtk.Bishop & mask) return rook_fear_bishop;
-			if (EnemyAtk.Rook & mask) return rook_fear_rook;
-			if (EnemyAtk.King & mask) return rook_fear_king;
-			if (EnemyAtk.Queen & mask) return rook_fear_queen;
-			return 0;
-		}
-		constexpr int queen_fear_penalty(const Square to){
-			const BitMask mask = ToMask(to);
-			if (EnemyAtk.Pawn & mask) return queen_fear_pawn;
-			if (EnemyAtk.Knight & mask) return queen_fear_knight;
-			if (EnemyAtk.Bishop & mask) return queen_fear_bishop;
-			if (EnemyAtk.Rook & mask) return queen_fear_rook;
-			if (EnemyAtk.Queen & mask) return queen_fear_queen;
-			if (EnemyAtk.King & mask) return queen_fear_king;
-			return 0;
-		}
-
-		constexpr int pawn_evade_bonus(const Square to){
-			const BitMask mask = ToMask(to);
-			if (EnemyAtk.Pawn & mask) return pawn_evade_pawn;
-			if (EnemyAtk.Knight & mask) return pawn_evade_knight;
-			if (EnemyAtk.King & mask) return pawn_evade_king;
-			if (EnemyAtk.Rook & mask) return pawn_evade_rook;
-			if (EnemyAtk.Bishop & mask) return pawn_evade_bishop;
-			if (EnemyAtk.Queen & mask) return pawn_evade_queen;
-			return 0;
-		}
-		constexpr int knight_evade_bonus(const Square to){
-			const BitMask mask = ToMask(to);
-			if (EnemyAtk.Pawn & mask) return knight_evade_pawn;
-			if (EnemyAtk.King & mask) return knight_evade_king;
-			if (EnemyAtk.Bishop & mask) return knight_evade_bishop;
-			if (EnemyAtk.Rook & mask) return knight_evade_rook;
-			if (EnemyAtk.Knight & mask) return knight_evade_knight;
-			if (EnemyAtk.Queen & mask) return knight_evade_queen;
-			return 0;
-		}
-		constexpr int bishop_evade_bonus(const Square to){
-			const BitMask mask = ToMask(to);
-			if (EnemyAtk.Pawn & mask) return bishop_evade_pawn;
-			if (EnemyAtk.Knight & mask) return bishop_evade_knight;
-			if (EnemyAtk.King & mask) return bishop_evade_king;
-			if (EnemyAtk.Rook & mask) return bishop_evade_rook;
-			if (EnemyAtk.Bishop & mask) return bishop_evade_bishop;
-			if (EnemyAtk.Queen & mask) return bishop_evade_queen;
-			return 0;
-		}
-		constexpr int rook_evade_bonus(const Square to){
-			const BitMask mask = ToMask(to);
-			if (EnemyAtk.Pawn & mask) return rook_evade_pawn;
-			if (EnemyAtk.Knight & mask) return rook_evade_knight;
-			if (EnemyAtk.Bishop & mask) return rook_evade_bishop;
-			if (EnemyAtk.Rook & mask) return rook_evade_rook;
-			if (EnemyAtk.King & mask) return rook_evade_king;
-			if (EnemyAtk.Queen & mask) return rook_evade_queen;
-			return 0;
-		}
-		constexpr int queen_evade_bonus(const Square to){
-			const BitMask mask = ToMask(to);
-			if (EnemyAtk.Pawn & mask) return queen_evade_pawn;
-			if (EnemyAtk.Knight & mask) return queen_evade_knight;
-			if (EnemyAtk.Bishop & mask) return queen_evade_bishop;
-			if (EnemyAtk.Rook & mask) return queen_evade_rook;
-			if (EnemyAtk.Queen & mask) return queen_evade_queen;
-			return 0;
-		}
-
-		inline void handle_promotions(const Square from, const Square to, const int freq){
-			const Move n = move_from_squares(from, to, PROMOTE_TO_KNIGHT);
-			Queue.push(std::make_tuple(freq + underpromote_to_knight_freq + match_bonus(n), n));
-			const Move b = move_from_squares(from, to, PROMOTE_TO_BISHOP);
-			Queue.push(std::make_tuple(freq + underpromote_to_bishop_freq + match_bonus(b), b));
-			const Move r = move_from_squares(from, to, PROMOTE_TO_ROOK);
-			Queue.push(std::make_tuple(freq + underpromote_to_rook_freq + match_bonus(r), r));
-			const Move q = move_from_squares(from, to, PROMOTE_TO_QUEEN);
-			Queue.push(std::make_tuple(freq + match_bonus(q), q));
-		}
-};
-
-template struct MoveQueue<true>;
-template struct MoveQueue<false>;
+template void MoveQueue::push_knight_move<true>(const Square, const Square);
+template void MoveQueue::push_knight_move<false>(const Square, const Square);
+template void MoveQueue::push_bishop_move<true>(const Square, const Square);
+template void MoveQueue::push_bishop_move<false>(const Square, const Square);
+template void MoveQueue::push_rook_move<true>(const Square, const Square);
+template void MoveQueue::push_rook_move<false>(const Square, const Square);
+template void MoveQueue::push_queen_move<true>(const Square, const Square);
+template void MoveQueue::push_queen_move<false>(const Square, const Square);
+template void MoveQueue::push_king_move<true>(const Square, const Square);
+template void MoveQueue::push_king_move<false>(const Square, const Square);
+template void MoveQueue::push_castle_qs<true>();
+template void MoveQueue::push_castle_qs<false>();
+template void MoveQueue::push_castle_ks<true>();
+template void MoveQueue::push_castle_ks<false>();
+template void MoveQueue::push_single_pawn_move<true>(const Square);
+template void MoveQueue::push_single_pawn_move<false>(const Square);
+template void MoveQueue::push_double_pawn_move<true>(const Square);
+template void MoveQueue::push_double_pawn_move<false>(const Square);
+template void MoveQueue::push_pawn_capture_left<true>(const Square);
+template void MoveQueue::push_pawn_capture_left<false>(const Square);
+template void MoveQueue::push_pawn_capture_right<true>(const Square);
+template void MoveQueue::push_pawn_capture_right<false>(const Square);
+template void MoveQueue::push_ep_capture_left<true>(const Square);
+template void MoveQueue::push_ep_capture_left<false>(const Square);
+template void MoveQueue::push_ep_capture_right<true>(const Square);
+template void MoveQueue::push_ep_capture_right<false>(const Square);

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -266,7 +266,7 @@ MoveQueue generate_moves(const Board &board, const ChecksAndPins cnp, const Move
 
 template <bool white>
 MoveQueue generate_forcing(const Board &board, const ChecksAndPins cnp){
-	BitMask enemy_occ = get_side<white>(board).All;
+	BitMask enemy_occ = get_side<not white>(board).All;
 	auto queue = MoveQueue(white, board);
 
 	BitMask pawn_target = enemy_occ | (white ? RANK_8 : RANK_1);

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -9,12 +9,12 @@
 /* KNIGHTS */
 
 template <bool white>
-void generate_knight_moves(const Board &board, const ChecksAndPins cnp, MoveQueue<white> &queue){
+void generate_knight_moves(const Board &board, const ChecksAndPins cnp, MoveQueue &queue){
 	Bitloop(get_side<white>(board).Knight & ~(cnp.HVPin | cnp.DiagPin), knights){
 		const Square source = TZCNT(knights);
 		const BitMask attacks = knight_lookup[source];
 		Bitloop(attacks & cnp.CheckMask & ~get_side<white>(board).All, target){
-			queue.push_knight_move(source, TZCNT(target));
+			queue.push_knight_move<white>(source, TZCNT(target));
 		}
 	}
 }
@@ -27,11 +27,11 @@ constexpr BitMask knight_checks(const BitMask knights, const Square king){
 /* KINGS */
 
 template <bool white>
-void generate_king_moves(const Board &board, const BitMask enemy_control, MoveQueue<white> &queue){
+void generate_king_moves(const Board &board, const BitMask enemy_control, MoveQueue &queue){
 	const HalfBoard &friendly = get_side<white>(board);
 	const BitMask attacks = king_lookup[friendly.King];
 	Bitloop(attacks & ~enemy_control & ~friendly.All, target){
-		queue.push_king_move(friendly.King, TZCNT(target));
+		queue.push_king_move<white>(friendly.King, TZCNT(target));
 	}
 
 	if (friendly.Castle & ToMask(white ? A1 : A8)){
@@ -39,7 +39,7 @@ void generate_king_moves(const Board &board, const BitMask enemy_control, MoveQu
 				(ToMask(B8) | ToMask(C8) | ToMask(D8))))){
 			if (not (enemy_control & (white ? (ToMask(C1) | ToMask(D1) | ToMask(E1)) :
 					(ToMask(C8) | ToMask(D8) | ToMask(E8))))){
-				queue.push_castle_qs();
+				queue.push_castle_qs<white>();
 			}
 		}
 	}
@@ -48,7 +48,7 @@ void generate_king_moves(const Board &board, const BitMask enemy_control, MoveQu
 		if (not (board.Occ & (white ? (ToMask(F1) | ToMask(G1)) : (ToMask(F8) | ToMask(G8))))){
 			if (not (enemy_control & (white ? (ToMask(E1) | ToMask(F1) | ToMask(G1)) :
 					(ToMask(E8) | ToMask(F8) | ToMask(G8))))){
-				queue.push_castle_ks();
+				queue.push_castle_ks<white>();
 			}
 		}
 	}
@@ -57,22 +57,22 @@ void generate_king_moves(const Board &board, const BitMask enemy_control, MoveQu
 /* ROOKS */
 
 template <bool white, bool queen>
-void generate_rook_moves(const Board &board, const ChecksAndPins cnp, MoveQueue<white> &queue){
+void generate_rook_moves(const Board &board, const ChecksAndPins cnp, MoveQueue &queue){
 	const BitMask pieces = queen ? get_side<white>(board).Queen : get_side<white>(board).Rook;
 	Bitloop(pieces & ~(cnp.HVPin | cnp.DiagPin), unpinned){
 			const Square source = TZCNT(unpinned);
 			const BitMask attacks = rook_seen(source, board.Occ);
 			Bitloop(attacks & cnp.CheckMask & ~get_side<white>(board).All, target){
-				if (queen){queue.push_queen_move(source, TZCNT(target));}
-				else {queue.push_rook_move(source, TZCNT(target));}
+				if (queen){queue.push_queen_move<white>(source, TZCNT(target));}
+				else {queue.push_rook_move<white>(source, TZCNT(target));}
 			}
 		}
 	Bitloop(pieces & cnp.HVPin, pinned){
 		const Square source = TZCNT(pinned);
 		const BitMask attacks = rook_seen(source, board.Occ);
 		Bitloop(attacks & cnp.CheckMask & cnp.HVPin, target){
-			if (queen){queue.push_queen_move(source, TZCNT(target));}
-			else {queue.push_rook_move(source, TZCNT(target));}
+			if (queen){queue.push_queen_move<white>(source, TZCNT(target));}
+			else {queue.push_rook_move<white>(source, TZCNT(target));}
 		}
 	}
 }
@@ -113,23 +113,23 @@ std::tuple<BitMask, BitMask> rook_checks_and_pins(
 
 
 template <bool white, bool queen>
-void generate_bishop_moves(const Board &board, const ChecksAndPins cnp, MoveQueue<white> &queue){
+void generate_bishop_moves(const Board &board, const ChecksAndPins cnp, MoveQueue &queue){
 
 	const BitMask pieces = queen ? get_side<white>(board).Queen : get_side<white>(board).Bishop;
 	Bitloop(pieces & ~(cnp.HVPin | cnp.DiagPin), unpinned){
 			const Square source = TZCNT(unpinned);
 			const BitMask attacks = bishop_seen(source, board.Occ);
 			Bitloop(attacks & cnp.CheckMask & ~get_side<white>(board).All, target){
-				if (queen){queue.push_queen_move(source, TZCNT(target));}
-				else {queue.push_bishop_move(source, TZCNT(target));}
+				if (queen){queue.push_queen_move<white>(source, TZCNT(target));}
+				else {queue.push_bishop_move<white>(source, TZCNT(target));}
 			}
 		}
 	Bitloop(pieces & cnp.DiagPin, pinned){
 		const Square source = TZCNT(pinned);
 		const BitMask attacks = bishop_seen(source, board.Occ);
 		Bitloop(attacks & cnp.CheckMask & cnp.DiagPin, target){
-			if (queen){queue.push_queen_move(source, TZCNT(target));}
-			else {queue.push_bishop_move(source, TZCNT(target));}
+			if (queen){queue.push_queen_move<white>(source, TZCNT(target));}
+			else {queue.push_bishop_move<white>(source, TZCNT(target));}
 		}
 	}
 
@@ -181,7 +181,7 @@ constexpr bool is_ep_pin_edge_case(const Square king, const BitMask enemy_rooks,
 }
 
 template <bool white>
-void generate_pawn_moves(const Board &board, const ChecksAndPins cnp, MoveQueue<white> &queue){
+void generate_pawn_moves(const Board &board, const ChecksAndPins cnp, MoveQueue &queue){
 	const HalfBoard &friendly = get_side<white>(board);
 	const HalfBoard &enemy = get_side<not white>(board);
 
@@ -189,22 +189,22 @@ void generate_pawn_moves(const Board &board, const ChecksAndPins cnp, MoveQueue<
 			(~cnp.HVPin | shift_back<white>(cnp.HVPin, 8));
 	Bitloop(can_push & shift_back<white>(cnp.CheckMask, 8), loop_var){
 		const Square source = TZCNT(loop_var);
-		queue.push_single_pawn_move(source);
+		queue.push_single_pawn_move<white>(source);
 	}
 	Bitloop(can_push & (white ? RANK_2 : RANK_7) &
 			shift_back<white>(cnp.CheckMask & ~board.Occ, 16), loop_var){
 		const Square source = TZCNT(loop_var);
-		queue.push_double_pawn_move(source);
+		queue.push_double_pawn_move<white>(source);
 	}
 	Bitloop(friendly.Pawn & shift_back<white>(cnp.CheckMask & enemy.All, 7) & ~LEFTMOST_FILE<white> &
 			~cnp.HVPin & (shift_back<white>(cnp.DiagPin, 7) | ~cnp.DiagPin), loop_var){
 		const Square source = TZCNT(loop_var);
-		queue.push_pawn_capture_left(source);
+		queue.push_pawn_capture_left<white>(source);
 	}
 	Bitloop(friendly.Pawn & shift_back<white>(cnp.CheckMask & enemy.All, 9) & ~RIGHTMOST_FILE<white> &
 			~cnp.HVPin & (shift_back<white>(cnp.DiagPin, 9) | ~cnp.DiagPin), loop_var){
 		const Square source = TZCNT(loop_var);
-		queue.push_pawn_capture_right(source);
+		queue.push_pawn_capture_right<white>(source);
 	}
 	const BitMask ep_left = friendly.Pawn & shift_forward<white>(cnp.CheckMask & board.EPMask, 1)
 			& ~LEFTMOST_FILE<white> & EP_RANK<white> & ~cnp.HVPin & (shift_back<white>(cnp.DiagPin, 7) | ~cnp.DiagPin);
@@ -212,7 +212,7 @@ void generate_pawn_moves(const Board &board, const ChecksAndPins cnp, MoveQueue<
 		if (not is_ep_pin_edge_case<white>(friendly.King, enemy.Rook | enemy.Queen,
 				board.Occ & ~(ep_left | board.EPMask))){
 			const Square source = TZCNT(ep_left);
-			queue.push_ep_capture_left(source);
+			queue.push_ep_capture_left<white>(source);
 		}
 	}
 	const BitMask ep_right = friendly.Pawn & shift_back<white>(cnp.CheckMask & board.EPMask, 1)
@@ -221,7 +221,7 @@ void generate_pawn_moves(const Board &board, const ChecksAndPins cnp, MoveQueue<
 		if (not is_ep_pin_edge_case<white>(friendly.King, enemy.Rook | enemy.Queen,
 				board.Occ & ~(ep_right | board.EPMask))){
 			const Square source = TZCNT(ep_right);
-			queue.push_ep_capture_right(source);
+			queue.push_ep_capture_right<white>(source);
 		}
 	}
 }
@@ -249,8 +249,8 @@ ChecksAndPins checks_and_pins(const Board &board){
 }
 
 template <bool white>
-MoveQueue<white> generate_moves(const Board &board, const ChecksAndPins cnp, const Move hint, const Move killer1, const Move killer2){
-	auto queue = MoveQueue<white>(board, hint, killer1, killer2);
+MoveQueue generate_moves(const Board &board, const ChecksAndPins cnp, const Move hint, const Move killer1, const Move killer2){
+	auto queue = MoveQueue(white, board, hint, killer1, killer2);
 
 	generate_pawn_moves<white>(board, cnp, queue);
 	generate_knight_moves<white>(board, cnp, queue);
@@ -260,13 +260,14 @@ MoveQueue<white> generate_moves(const Board &board, const ChecksAndPins cnp, con
 	generate_rook_moves<white, true>(board, cnp, queue);
 	generate_king_moves<white>(board, white ? board.BkAtk.all() : board.WtAtk.all(), queue);
 
+	queue.heapify();
 	return queue;
 }
 
 template <bool white>
-MoveQueue<white> generate_forcing(const Board &board, const ChecksAndPins cnp){
-	BitMask enemy_occ = get_side<not white>(board).All;
-	auto queue = MoveQueue<white>(board);
+MoveQueue generate_forcing(const Board &board, const ChecksAndPins cnp){
+	BitMask enemy_occ = get_side<white>(board).All;
+	auto queue = MoveQueue(white, board);
 
 	BitMask pawn_target = enemy_occ | (white ? RANK_8 : RANK_1);
 	generate_pawn_moves<white>(board, ChecksAndPins(pawn_target, cnp.HVPin, cnp.DiagPin), queue);
@@ -279,12 +280,13 @@ MoveQueue<white> generate_forcing(const Board &board, const ChecksAndPins cnp){
 	generate_rook_moves<white, true>(board, piece_cnp, queue);
 	generate_king_moves<white>(board, (white ? board.BkAtk.all() : board.WtAtk.all()) | ~enemy_occ, queue);
 
+	queue.heapify();
 	return queue;
 }
 
 template ChecksAndPins checks_and_pins<true>(const Board&);
 template ChecksAndPins checks_and_pins<false>(const Board&);
-template MoveQueue<true> generate_moves<true>(const Board&, const ChecksAndPins, const Move, const Move, const Move);
-template MoveQueue<false> generate_moves<false>(const Board&, const ChecksAndPins, const Move, const Move, const Move);
-template MoveQueue<true> generate_forcing<true>(const Board&, const ChecksAndPins);
-template MoveQueue<false> generate_forcing<false>(const Board&, const ChecksAndPins);
+template MoveQueue generate_moves<true>(const Board&, const ChecksAndPins, const Move, const Move, const Move);
+template MoveQueue generate_moves<false>(const Board&, const ChecksAndPins, const Move, const Move, const Move);
+template MoveQueue generate_forcing<true>(const Board&, const ChecksAndPins);
+template MoveQueue generate_forcing<false>(const Board&, const ChecksAndPins);


### PR DESCRIPTION
There are three main benefits to this:
- The move queue is now stored on the stack instead of the heap, reducing the impact of memory fragmentation as we must come back to the same move list multiple times in the search. With this change, Rengar's only use of the heap will be the transposition table.
- By calling `std::make_heap` once rather than inserting each time, we reduce the number of comparisons and swaps when building the queue
- By saving popped moves at the back of the queue, we can come back to them later in the search (iterative deepening, move order adjustment, etc)

This appears to bump nodes per second by about 15%.