### PR TITLE
Dynamic move order

### DIFF
--- a/analysis/selfplay.py
+++ b/analysis/selfplay.py
@@ -320,6 +320,19 @@ def play_tournament(openings_path: Path, output_dir: Path, start_time_min: float
         df['Elo'] = compute_bayes_elo(df['Score'])
         print(df.sort_values('Score', ascending=False))
 
+        if 'main' in df.index:
+            main_t = df['T-Stat']['main']
+            if df['T-Stat'].max() > main_t + 5:
+                print(f"{df['T-Stat'].idxmax()} is a clear winner! Rebase before continuing")
+                return
+            while df['T-Stat'].min() < main_t - 5:
+                loser = df['T-Stat'].idxmin()
+                print(f"{loser} is a clear loser, dropping from tournament")
+                scores.pop(loser)
+                matchups = list(filter(
+                    lambda x: not (isinstance(x, TwoPlayer) and loser in (x.white_branch, x.black_branch)),
+                    matchups,
+                ))
 
 def main():
     parser = ArgumentParser()

--- a/includes/move_queue.hpp
+++ b/includes/move_queue.hpp
@@ -73,3 +73,5 @@ struct MoveQueue{
 		inline void handle_promotions(const Square from, const Square to, const int freq);
 		inline void push_move_helper(int priority, const Move move);
 };
+
+void show_move_order_values();

--- a/includes/move_queue.hpp
+++ b/includes/move_queue.hpp
@@ -15,6 +15,8 @@ struct ABCMask{
 
 ABCMask abc_for_halfboard(const HalfBoard &side);
 
+int initialize_move_order_arrays();
+
 struct MoveQueue{
 	MoveQueue(const bool white, const Board &board, const Move hint, const Move killer1, const Move killer2) :
 		Hint(hint), Killer1(killer1), Killer2(killer2), EnemyABC(abc_for_halfboard(white ? board.Black : board.White)),

--- a/includes/move_queue.hpp
+++ b/includes/move_queue.hpp
@@ -57,9 +57,13 @@ struct MoveQueue{
 	template <bool white>
 	void push_ep_capture_right(const Square from);
 
+	template <bool white>
+	void update_frequency_for_beta_cutoff();
+
 	private:
 		std::array<std::tuple<int, Move>, move_array_max_size> move_array;
 		size_t queue_length = 0;
+		size_t num_dequed_moves = 0;
 		const Move Hint = 0;
 		const Move Killer1 = 0;
 		const Move Killer2 = 0;

--- a/mains/uci.cpp
+++ b/mains/uci.cpp
@@ -93,6 +93,7 @@ int main() {
 		}
 		if (command == "ucinewgame"){
 			ht_init(HASH_KEY_LENGTH);
+			initialize_move_order_arrays();
 		}
 		if (command == "setoption"){
 			std::string arg;

--- a/mains/uci.cpp
+++ b/mains/uci.cpp
@@ -240,6 +240,9 @@ int main() {
 		if (command == "quit"){
 			return 0;
 		}
+		if (command == "moveorder"){
+			show_move_order_values();
+		}
 	}
 
 	return -1;

--- a/src/move_queue.cpp
+++ b/src/move_queue.cpp
@@ -503,3 +503,6 @@ void MoveQueue::update_frequency_for_beta_cutoff(){
 		adjust_frequency_param_for_move<white>(std::get<1>(move_array[queue_length + i]), -1);
 	}
 }
+
+template void MoveQueue::update_frequency_for_beta_cutoff<true>();
+template void MoveQueue::update_frequency_for_beta_cutoff<false>();

--- a/src/move_queue.cpp
+++ b/src/move_queue.cpp
@@ -12,7 +12,7 @@
 # endif
 
 
-MOVE_ORDER_PARAM_ARRAY(64, pawn_freq,
+const std::array<int, 64> starting_pawn_freq = {
 	 176,  190,  203,  202,  236,  253,  292,  245,
 	 200,  156,  162,  146,  172,  169,  208,  223,
 	 149,  110,  110,  103,   88,  119,  132,  164,
@@ -21,8 +21,8 @@ MOVE_ORDER_PARAM_ARRAY(64, pawn_freq,
 	 -48,  -93,   47,   51,   88, -100,  -66,  -25,
 	   0,    0,    0,    0,    0,    0,    0,    0,
 	   0,    0,    0,    0,    0,    0,    0,    0,
-)
-MOVE_ORDER_PARAM_ARRAY(64, knight_freq,
+};
+const std::array<int, 64> starting_knight_freq = {
 	-110,  -90,  -85,  -54,  -37,  -52,  -62, -153,
 	 -66,   -3,   -8,  -10,  -53,  -29,  -34,  -65,
 	 -27,   24,  105,   55,  103,   69,   52,   21,
@@ -31,8 +31,8 @@ MOVE_ORDER_PARAM_ARRAY(64, knight_freq,
 	-111,  -19,  148,   52,   62,  187,   62,  -84,
 	-206,  -80,  -24,  -35,  -26,   26,  -50, -130,
 	-202, -264,  -94, -147, -193,  -98, -254, -240,
-)
-MOVE_ORDER_PARAM_ARRAY(64, bishop_freq,
+};
+const std::array<int, 64> starting_bishop_freq = {
 	-171, -115,  -73,  -67,  -63,  -63, -122, -173,
 	-119,  -31,  -47,  -27,  -20,  -68,  -66, -101,
 	 -99,  -29,   29,   17,   32,   38,  -28,  -74,
@@ -41,8 +41,8 @@ MOVE_ORDER_PARAM_ARRAY(64, bishop_freq,
 	  -4,   23,   53,   71,   81,   34,   41, -101,
 	 -83,   63,   -4,  -26,   23,   -5,  126, -105,
 	-204, -121, -156,  -74, -117, -125, -158, -282,
-)
-MOVE_ORDER_PARAM_ARRAY(64, rook_freq,
+};
+const std::array<int, 64> starting_rook_freq = {
 	  21,    5,   39,   33,   53,   32,   23,    2,
 	  38,   36,   59,   45,   16,   -2,   16,   15,
 	  18,   23,   21,    8,   -4,   11,   21,   11,
@@ -51,8 +51,8 @@ MOVE_ORDER_PARAM_ARRAY(64, rook_freq,
 	 -54,  -30,  -37,  -55,  -28,    6,    7,  -45,
 	-104,  -38,  -59,  -68,  -84,   -7,  -25,  -69,
 	-114,  -94,  -13,   58,   18,  -83, -149, -115,
-)
-MOVE_ORDER_PARAM_ARRAY(64, queen_freq,
+};
+const std::array<int, 64> starting_queen_freq = {
 	 -43,  -12,   29,   15,   34,  -30,  -36,  -12,
 	 -14,   20,   38,   26,   36,  -25,  -73,  -74,
 	 -24,    6,   20,   26,   50,   48,   29,    7,
@@ -61,8 +61,8 @@ MOVE_ORDER_PARAM_ARRAY(64, queen_freq,
 	 -72,  -10,    8,  -27,   32,   38,   78,  -23,
 	-111,  -31,    8,  -47,  -14,   36,  -13, -100,
 	 -90, -198, -143,  -72, -156, -134,  -95, -136,
-)
-MOVE_ORDER_PARAM_ARRAY(64, king_freq,
+};
+const std::array<int, 64> starting_king_freq = {
 	-155, -103, -116, -152, -166, -110,  -92, -189,
 	-121,  -23,  -49,   -6,  -34,   13,  -38, -121,
 	 -65,   53,   65,    2,   21,   89,  105,  -67,
@@ -71,7 +71,35 @@ MOVE_ORDER_PARAM_ARRAY(64, king_freq,
 	 -97,  -27,    9,    7,   32,   32,   13, -103,
 	-114,  -39,  -22,  -82,  -46,  -26,    4, -108,
 	-186,  -46, -100, -139, -125, -160,  -79, -241,
-)
+};
+
+std::array<int, 64> white_pawn_freq;
+std::array<int, 64> white_knight_freq;
+std::array<int, 64> white_bishop_freq;
+std::array<int, 64> white_rook_freq;
+std::array<int, 64> white_queen_freq;
+std::array<int, 64> white_king_freq;
+
+std::array<int, 64> black_pawn_freq;
+std::array<int, 64> black_knight_freq;
+std::array<int, 64> black_bishop_freq;
+std::array<int, 64> black_rook_freq;
+std::array<int, 64> black_queen_freq;
+std::array<int, 64> black_king_freq;
+
+int initialize_move_order_arrays(){
+	for (int i=0; i<64; i++){
+		black_pawn_freq[i] = white_pawn_freq[FlipIf(true, i)] = starting_pawn_freq[i];
+		black_knight_freq[i] = white_knight_freq[FlipIf(true, i)] = starting_knight_freq[i];
+		black_bishop_freq[i] = white_bishop_freq[FlipIf(true, i)] = starting_bishop_freq[i];
+		black_rook_freq[i] = white_rook_freq[FlipIf(true, i)] = starting_rook_freq[i];
+		black_queen_freq[i] = white_queen_freq[FlipIf(true, i)] = starting_queen_freq[i];
+		black_king_freq[i] = white_king_freq[FlipIf(true, i)] = starting_king_freq[i];
+	}
+	return 0;
+}
+
+const int _unused2 = initialize_move_order_arrays();
 
 MOVE_ORDER_PARAM_ARRAY(6, pawn_capture_freq,
 	  0, 208, 295, 313, 293, 393,
@@ -314,35 +342,39 @@ inline void MoveQueue::handle_promotions(const Square from, const Square to, con
 template <bool white>
 void MoveQueue::push_knight_move(const Square from, const Square to){
 	const Move move = move_from_squares(from, to, KNIGHT_MOVE);
-	const int base_prio = knight_freq[FlipIf(white, to)] + knight_capture_freq[piece_at_square(to, EnemyABC)]
+	const int base_prio = (white ? white_knight_freq : black_knight_freq)[to] 
+		+ knight_capture_freq[piece_at_square(to, EnemyABC)]
 		- knight_fear_penalty(to, EnemyAtk) + knight_evade_bonus(from, EnemyAtk);
 	push_move_helper(base_prio, move);
 }
 template <bool white>
 void MoveQueue::push_bishop_move(const Square from, const Square to){
 	const Move move = move_from_squares(from, to, BISHOP_MOVE);
-	const int base_prio = bishop_freq[FlipIf(white, to)] + bishop_capture_freq[piece_at_square(to, EnemyABC)]
+	const int base_prio = (white ? white_bishop_freq : black_bishop_freq)[to] 
+		+ bishop_capture_freq[piece_at_square(to, EnemyABC)]
 		- bishop_fear_penalty(to, EnemyAtk) + bishop_evade_bonus(from, EnemyAtk);
 	push_move_helper(base_prio, move);
 }
 template <bool white>
 void MoveQueue::push_rook_move(const Square from, const Square to){
 	const Move move = move_from_squares(from, to, ROOK_MOVE);
-	const int base_prio = rook_freq[FlipIf(white, to)] + rook_capture_freq[piece_at_square(to, EnemyABC)]
+	const int base_prio = (white ? white_rook_freq : black_rook_freq)[to] 
+		+ rook_capture_freq[piece_at_square(to, EnemyABC)]
 		- rook_fear_penalty(to, EnemyAtk) + rook_evade_bonus(from, EnemyAtk);
 	push_move_helper(base_prio, move);
 }
 template <bool white>
 void MoveQueue::push_queen_move(const Square from, const Square to){
 	const Move move = move_from_squares(from, to, QUEEN_MOVE);
-	const int base_prio = queen_freq[FlipIf(white, to)] + queen_capture_freq[piece_at_square(to, EnemyABC)]
+	const int base_prio = (white ? white_queen_freq : black_queen_freq)[to] 
+		+ queen_capture_freq[piece_at_square(to, EnemyABC)]
 		- queen_fear_penalty(to, EnemyAtk) + queen_evade_bonus(from, EnemyAtk);
 	push_move_helper(base_prio, move);
 }
 template <bool white>
 void MoveQueue::push_king_move(const Square from, const Square to){
 	const Move move = move_from_squares(from, to, KING_MOVE);
-	const int base_prio = king_freq[FlipIf(white, to)] + king_capture_freq[piece_at_square(to, EnemyABC)];
+	const int base_prio = (white ? white_king_freq : black_king_freq)[to] + king_capture_freq[piece_at_square(to, EnemyABC)];
 	push_move_helper(base_prio, move);
 }
 template <bool white>
@@ -358,7 +390,8 @@ void MoveQueue::push_castle_ks(){
 template <bool white>
 void MoveQueue::push_single_pawn_move(const Square from){
 	const Square to = white ? (from + 8) : (from - 8);
-	const int freq = pawn_freq[FlipIf(white, to)] - pawn_fear_penalty(to, EnemyAtk) + pawn_evade_bonus(from, EnemyAtk);
+	const int freq = (white ? white_pawn_freq : black_pawn_freq)[to] 
+		- pawn_fear_penalty(to, EnemyAtk) + pawn_evade_bonus(from, EnemyAtk);
 	if (white ? (to >= A8) : (to <= H1)) {
 		handle_promotions(from, to, freq);
 	} else {
@@ -370,13 +403,14 @@ template <bool white>
 void MoveQueue::push_double_pawn_move(const Square from){
 	const Square to = white ? (from + 16) : (from - 16);
 	const Move move = move_from_squares(from, to, DOUBLE_PAWN_PUSH);
-	const int move_prio = pawn_freq[FlipIf(white, to)] - pawn_fear_penalty(to, EnemyAtk) + pawn_evade_bonus(from, EnemyAtk);
+	const int move_prio = (white ? white_pawn_freq : black_pawn_freq)[to]
+		- pawn_fear_penalty(to, EnemyAtk) + pawn_evade_bonus(from, EnemyAtk);
 	push_move_helper(move_prio, move);
 }
 template <bool white>
 void MoveQueue::push_pawn_capture_left(const Square from){
 	const Square to = white ? (from + 7) : (from - 7);
-	const int freq = pawn_freq[FlipIf(white, to)] + pawn_capture_freq[piece_at_square(to, EnemyABC)] 
+	const int freq = (white ? white_pawn_freq : black_pawn_freq)[to] + pawn_capture_freq[piece_at_square(to, EnemyABC)] 
 		- pawn_fear_penalty(to, EnemyAtk) + pawn_evade_bonus(from, EnemyAtk);
 	if (white ? (to >= A8) : (to <= H1)) {
 		handle_promotions(from, to, freq);
@@ -388,7 +422,7 @@ void MoveQueue::push_pawn_capture_left(const Square from){
 template <bool white>
 void MoveQueue::push_pawn_capture_right(const Square from){
 	const Square to = white ? (from + 9) : (from - 9);
-	const int freq = pawn_freq[FlipIf(white, to)] + pawn_capture_freq[piece_at_square(to, EnemyABC)] 
+	const int freq =(white ? white_pawn_freq : black_pawn_freq)[to] + pawn_capture_freq[piece_at_square(to, EnemyABC)] 
 		- pawn_fear_penalty(to, EnemyAtk) + pawn_evade_bonus(from, EnemyAtk);
 	if (white ? (to >= A8) : (to <= H1)) {
 		handle_promotions(from, to, freq);

--- a/src/move_queue.cpp
+++ b/src/move_queue.cpp
@@ -1,5 +1,6 @@
 # include <algorithm>
 # include <stdexcept>
+# include <iostream>
 # include "move_queue.hpp"
 
 # ifdef TUNE_MOVE_ORDER
@@ -506,3 +507,45 @@ void MoveQueue::update_frequency_for_beta_cutoff(){
 
 template void MoveQueue::update_frequency_for_beta_cutoff<true>();
 template void MoveQueue::update_frequency_for_beta_cutoff<false>();
+
+void show_board_array(std::array<int, 64> arr){
+	for (size_t i = 0; i < 64; i++){
+		std::cout << "\t" << arr[i] << ",";
+		if (i%8 == 7) std::cout << std::endl;
+	}
+}
+
+void show_move_order_values(){
+	std::cout << "white pawn:" << std::endl;
+	show_board_array(white_pawn_freq);
+	std::cout << "white knight:" << std::endl;
+	show_board_array(white_knight_freq);
+	std::cout << "white bishop:" << std::endl;
+	show_board_array(white_bishop_freq);
+	std::cout << "white rook:" << std::endl;
+	show_board_array(white_rook_freq);
+	std::cout << "white queen:" << std::endl;
+	show_board_array(white_queen_freq);
+	std::cout << "white king:" << std::endl;
+	show_board_array(white_king_freq);
+	std::cout << "white castle queenside:" << white_castle_qs_freq << std::endl;
+	std::cout << "white castle kingside:" << white_castle_ks_freq << std::endl;
+	std::cout << "white en passant:" << white_en_passant_freq << std::endl;
+
+	std::cout << "black pawn:" << std::endl;
+	show_board_array(black_pawn_freq);
+	std::cout << "black knight:" << std::endl;
+	show_board_array(black_knight_freq);
+	std::cout << "black bishop:" << std::endl;
+	show_board_array(black_bishop_freq);
+	std::cout << "black rook:" << std::endl;
+	show_board_array(black_rook_freq);
+	std::cout << "black queen:" << std::endl;
+	show_board_array(black_queen_freq);
+	std::cout << "black king:" << std::endl;
+	show_board_array(black_king_freq);
+	std::cout << "black castle queenside:" << black_castle_qs_freq << std::endl;
+	std::cout << "black castle kingside:" << black_castle_ks_freq << std::endl;
+	std::cout << "black en passant:" << black_en_passant_freq << std::endl;
+
+}

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -176,6 +176,7 @@ std::tuple<int, VariationView, int> search_helper(const Board &board, const int 
 		if (branch_eval > best_eval) {
 			best_var = branch_var.prepend(branch_move);
 			best_eval = branch_eval;
+			if (branch_eval > alpha) queue.template update_frequency_for_beta_cutoff<white>();
 		} else if (branch_var.length) {
 			const Move refutation = branch_var.head();
 			if ((refutation != child_killer1) and (move_destination(refutation) != move_destination(branch_move))) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -226,24 +226,24 @@ Move search_for_move(const Board &board, History &history, const int node_limit,
 	VariationWorkspace workspace;
 	VariationView var = VariationView(workspace);
 
-	int depth = 0;
-	int eval = 0;
-	while ((positions_seen < node_limit) and (depth < depth_limit) and (timer.ms_elapsed() < min_time_ms)){
-		depth++;
-		try {
+	try {
+		int depth = 0;
+		int eval = 0;
+		while ((positions_seen < node_limit) and (depth < depth_limit) and (timer.ms_elapsed() < min_time_ms)){
+			depth++;
 			std::tie(eval, var, std::ignore) = search_helper<white>(board, depth, 
 				2 * CHECKMATED, -2 * CHECKMATED, history, var, 0, 0);
-		} catch (NodeLimitSafety e) { }
 
-		auto ms_elapsed = timer.ms_elapsed();
-		if ((ms_elapsed > 0) and (max_time_ms < INT_MAX)) {
-			auto npms = positions_seen / ms_elapsed;
-			_global_node_limit = npms * max_time_ms;
+			auto ms_elapsed = timer.ms_elapsed();
+			if ((ms_elapsed > 0) and (max_time_ms < INT_MAX)) {
+				auto npms = positions_seen / ms_elapsed;
+				_global_node_limit = npms * max_time_ms;
+			}
+			if (log_level >= 2) { log_info(ms_elapsed, depth, var, eval); }
 		}
-		if (log_level >= 2) { log_info(ms_elapsed, depth, var, eval); }
-	}
 
-	if (log_level == 1) { log_info(timer.ms_elapsed(), depth, var, eval); }
+		if (log_level == 1) { log_info(timer.ms_elapsed(), depth, var, eval); }
+	} catch (NodeLimitSafety e) { }
 	return var.head();
 }
 


### PR DESCRIPTION
The piece square tables for move order are no longer fixed. When one move beats others earlier in the move order (while raising alpha), its priority goes up by one for each move it beat, while the moves it beat each go down by one.

Based on testing this change should be a big deal and is a clear winner, so I'm going to rebase other potential 1.3 changes onto this before continuing the tournament. This PR has the code to cut the tournament off in such cases (and drop poor performing branches).
```
                              Score  T-Stat   Win  Draw  Loss    Elo
dynamic-move-order             93.0    6.11  74.0  38.0  16.0  146.0
bishop-pair                    72.5    1.74  56.0  33.0  39.0   38.0
main                           65.0    0.23  39.0  52.0  37.0    0.0
aspiration-windows             64.5    0.11  39.0  51.0  38.0   -2.0
tune-tables                    64.0    0.00  46.0  36.0  46.0   -5.0
use-32nd-of-time               59.0   -1.03  42.0  34.0  52.0  -30.0
tune-move-order                53.0   -2.29  35.0  36.0  57.0  -60.0
internal-iterative-deepening   52.5   -2.44  33.0  39.0  56.0  -63.0
lmr-4                          52.5   -2.59  28.0  49.0  51.0  -63.0
```

I also fixed a bug (exposed in this tournament) where the pv logged prior to playing a move at the time safety could have illegal moves. Instead Rengar will not log at all and just give the best move.