### PR TITLE
Fix for loops and search explosion when mate is forced

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -186,7 +186,7 @@ std::tuple<int, VariationView, int> search_helper(const Board &board, const int 
 		}
 
 		queue.pop();
-		move_index += 1;
+		if (branch_eval > CHECKMATED) move_index += 1;
 		if (move_index == reduction_index_cutoff) {
 			depth_reduction += 1;
 			reduction_index_cutoff *= 2;
@@ -228,13 +228,14 @@ Move search_for_move(const Board &board, History &history, const int node_limit,
 
 	int depth = 0;
 	int eval = 0;
+	int ms_elapsed = 0;
 	try {
-		while ((positions_seen < node_limit) and (depth < depth_limit) and (timer.ms_elapsed() < min_time_ms)){
+		while ((depth < depth_limit) and (ms_elapsed < min_time_ms) and (eval > CHECKMATED) and (eval < -CHECKMATED)){
 			depth++;
 			std::tie(eval, var, std::ignore) = search_helper<white>(board, depth, 
 				2 * CHECKMATED, -2 * CHECKMATED, history, var, 0, 0);
 
-			auto ms_elapsed = timer.ms_elapsed();
+			ms_elapsed = timer.ms_elapsed();
 			if ((ms_elapsed > 0) and (max_time_ms < INT_MAX)) {
 				auto npms = positions_seen / ms_elapsed;
 				_global_node_limit = npms * max_time_ms;
@@ -242,7 +243,7 @@ Move search_for_move(const Board &board, History &history, const int node_limit,
 			if (log_level >= 2) { log_info(ms_elapsed, depth, var, eval); }
 		}
 
-		if (log_level == 1) { log_info(timer.ms_elapsed(), depth, var, eval); }
+		if (log_level == 1) { log_info(ms_elapsed, depth, var, eval); }
 	} catch (NodeLimitSafety e) { 
 		if (log_level >= 1) log_info(timer.ms_elapsed(), depth, var.singleton(var.head()), eval);
 	}


### PR DESCRIPTION
There's another problem with #26. When Rengar finds a forced mate, it will loop for a long time finding it over and over again until at some point the depth gets so large that the pruning threshold catches up to the mate score. This begins a very long search that can cause a timeout, and because the mate loop took <1ms the time safety isn't even active yet.

My solution is to return on mate scores while ensuring that mate scores actually mean mate is forced. The only reason this wasn't true in the first place is that late move reductions could prune a mate preventing move a low depth. So instead we don't increment the reduction counter if an early move is refuted by a checkmate.