### PR TITLE
Bishop pair and other evaluation enhancements

### DIFF
--- a/includes/pst.hpp
+++ b/includes/pst.hpp
@@ -56,6 +56,9 @@ struct PstEvalInfo{
 	void castle_queenside();
 	template <bool white>
 	void castle_kingside();
+
+	template <bool white>
+	void remove_bishop_pair_bonus();
 };
 
 PstEvalInfo half_to_full_eval_info(const PstEvalInfo &w, const PstEvalInfo &b);

--- a/includes/weights/endgame.hpp
+++ b/includes/weights/endgame.hpp
@@ -2,13 +2,12 @@
 
 # include "eval_param.hpp"
 
-EVAL_PARAM(eg_pawn, 141)
-EVAL_PARAM(eg_knight, 372)
-EVAL_PARAM(eg_bishop, 359)
-EVAL_PARAM(eg_rook, 637)
-EVAL_PARAM(eg_queen, 1162)
-
-EVAL_PARAM(eg_bishop_pair, 0)
+EVAL_PARAM(eg_pawn, 138)
+EVAL_PARAM(eg_knight, 375)
+EVAL_PARAM(eg_bishop, 352)
+EVAL_PARAM(eg_rook, 642)
+EVAL_PARAM(eg_queen, 1172)
+EVAL_PARAM(eg_bishop_pair, 40)
 
 EVAL_PARAM_ARRAY(64, eg_pawn_table,
 	  0,   0,   0,   0,   0,   0,   0,   0,

--- a/includes/weights/endgame.hpp
+++ b/includes/weights/endgame.hpp
@@ -2,12 +2,13 @@
 
 # include "eval_param.hpp"
 
-EVAL_PARAM(eg_pawn, 136)
-EVAL_PARAM(eg_knight, 370)
-EVAL_PARAM(eg_bishop, 354)
-EVAL_PARAM(eg_rook, 643)
-EVAL_PARAM(eg_queen, 1165)
-EVAL_PARAM(eg_bishop_pair, 49)
+EVAL_PARAM(eg_pawn, 141)
+EVAL_PARAM(eg_knight, 372)
+EVAL_PARAM(eg_bishop, 359)
+EVAL_PARAM(eg_rook, 637)
+EVAL_PARAM(eg_queen, 1162)
+
+EVAL_PARAM(eg_bishop_pair, 0)
 
 EVAL_PARAM_ARRAY(64, eg_pawn_table,
 	  0,   0,   0,   0,   0,   0,   0,   0,

--- a/includes/weights/endgame.hpp
+++ b/includes/weights/endgame.hpp
@@ -8,6 +8,8 @@ EVAL_PARAM(eg_bishop, 359)
 EVAL_PARAM(eg_rook, 637)
 EVAL_PARAM(eg_queen, 1162)
 
+EVAL_PARAM(eg_bishop_pair, 0)
+
 EVAL_PARAM_ARRAY(64, eg_pawn_table,
 	  0,   0,   0,   0,   0,   0,   0,   0,
 	163, 154, 138, 134, 134, 138, 154, 163,

--- a/includes/weights/endgame.hpp
+++ b/includes/weights/endgame.hpp
@@ -2,13 +2,12 @@
 
 # include "eval_param.hpp"
 
-EVAL_PARAM(eg_pawn, 141)
-EVAL_PARAM(eg_knight, 372)
-EVAL_PARAM(eg_bishop, 359)
-EVAL_PARAM(eg_rook, 637)
-EVAL_PARAM(eg_queen, 1162)
-
-EVAL_PARAM(eg_bishop_pair, 0)
+EVAL_PARAM(eg_pawn, 136)
+EVAL_PARAM(eg_knight, 370)
+EVAL_PARAM(eg_bishop, 354)
+EVAL_PARAM(eg_rook, 643)
+EVAL_PARAM(eg_queen, 1165)
+EVAL_PARAM(eg_bishop_pair, 49)
 
 EVAL_PARAM_ARRAY(64, eg_pawn_table,
 	  0,   0,   0,   0,   0,   0,   0,   0,

--- a/includes/weights/osc_middlegame.hpp
+++ b/includes/weights/osc_middlegame.hpp
@@ -8,6 +8,8 @@ EVAL_PARAM(osc_mg_bishop, 297)
 EVAL_PARAM(osc_mg_rook, 372)
 EVAL_PARAM(osc_mg_queen, 814)
 
+EVAL_PARAM(osc_mg_bishop_pair, 0)
+
 // All tables can be viewed from white's perspective where white is castled queenside and black is castled kingside
 
 EVAL_PARAM_ARRAY(64, osc_mg_pawn_table,

--- a/includes/weights/osc_middlegame.hpp
+++ b/includes/weights/osc_middlegame.hpp
@@ -2,13 +2,12 @@
 
 # include "eval_param.hpp"
 
-EVAL_PARAM(osc_mg_pawn, 63)
-EVAL_PARAM(osc_mg_knight, 311)
-EVAL_PARAM(osc_mg_bishop, 297)
-EVAL_PARAM(osc_mg_rook, 372)
-EVAL_PARAM(osc_mg_queen, 814)
-
-EVAL_PARAM(osc_mg_bishop_pair, 0)
+EVAL_PARAM(osc_mg_pawn, 86)
+EVAL_PARAM(osc_mg_knight, 321)
+EVAL_PARAM(osc_mg_bishop, 292)
+EVAL_PARAM(osc_mg_rook, 349)
+EVAL_PARAM(osc_mg_queen, 761)
+EVAL_PARAM(osc_mg_bishop_pair, 23)
 
 // All tables can be viewed from white's perspective where white is castled queenside and black is castled kingside
 

--- a/includes/weights/osc_middlegame.hpp
+++ b/includes/weights/osc_middlegame.hpp
@@ -2,13 +2,12 @@
 
 # include "eval_param.hpp"
 
-EVAL_PARAM(osc_mg_pawn, 63)
-EVAL_PARAM(osc_mg_knight, 311)
-EVAL_PARAM(osc_mg_bishop, 297)
-EVAL_PARAM(osc_mg_rook, 372)
-EVAL_PARAM(osc_mg_queen, 814)
-
-EVAL_PARAM(osc_mg_bishop_pair, 0)
+EVAL_PARAM(osc_mg_pawn, 83)
+EVAL_PARAM(osc_mg_knight, 314)
+EVAL_PARAM(osc_mg_bishop, 307)
+EVAL_PARAM(osc_mg_rook, 341)
+EVAL_PARAM(osc_mg_queen, 762)
+EVAL_PARAM(osc_mg_bishop_pair, 10)
 
 // All tables can be viewed from white's perspective where white is castled queenside and black is castled kingside
 

--- a/includes/weights/osc_middlegame.hpp
+++ b/includes/weights/osc_middlegame.hpp
@@ -2,12 +2,13 @@
 
 # include "eval_param.hpp"
 
-EVAL_PARAM(osc_mg_pawn, 83)
-EVAL_PARAM(osc_mg_knight, 314)
-EVAL_PARAM(osc_mg_bishop, 307)
-EVAL_PARAM(osc_mg_rook, 341)
-EVAL_PARAM(osc_mg_queen, 762)
-EVAL_PARAM(osc_mg_bishop_pair, 10)
+EVAL_PARAM(osc_mg_pawn, 63)
+EVAL_PARAM(osc_mg_knight, 311)
+EVAL_PARAM(osc_mg_bishop, 297)
+EVAL_PARAM(osc_mg_rook, 372)
+EVAL_PARAM(osc_mg_queen, 814)
+
+EVAL_PARAM(osc_mg_bishop_pair, 0)
 
 // All tables can be viewed from white's perspective where white is castled queenside and black is castled kingside
 

--- a/includes/weights/phase_count.hpp
+++ b/includes/weights/phase_count.hpp
@@ -2,9 +2,9 @@
 
 # include "eval_param.hpp"
 
-EVAL_PARAM(pc_pawn, 1)
-EVAL_PARAM(pc_knight, 3)
-EVAL_PARAM(pc_bishop, 16)
+EVAL_PARAM(pc_pawn,  2)
+EVAL_PARAM(pc_knight,  5)
+EVAL_PARAM(pc_bishop, 13)
 EVAL_PARAM(pc_rook, 17)
-EVAL_PARAM(pc_queen, 38)
-EVAL_PARAM(pc_intercept, 6)
+EVAL_PARAM(pc_queen, 40)
+EVAL_PARAM(pc_intercept, -1)

--- a/includes/weights/phase_count.hpp
+++ b/includes/weights/phase_count.hpp
@@ -2,9 +2,9 @@
 
 # include "eval_param.hpp"
 
-EVAL_PARAM(pc_pawn,  2)
-EVAL_PARAM(pc_knight,  5)
-EVAL_PARAM(pc_bishop, 13)
+EVAL_PARAM(pc_pawn, 1)
+EVAL_PARAM(pc_knight, 3)
+EVAL_PARAM(pc_bishop, 16)
 EVAL_PARAM(pc_rook, 17)
-EVAL_PARAM(pc_queen, 40)
-EVAL_PARAM(pc_intercept, -1)
+EVAL_PARAM(pc_queen, 38)
+EVAL_PARAM(pc_intercept, 6)

--- a/includes/weights/phase_count.hpp
+++ b/includes/weights/phase_count.hpp
@@ -2,9 +2,9 @@
 
 # include "eval_param.hpp"
 
-EVAL_PARAM(pc_pawn,  2)
-EVAL_PARAM(pc_knight,  5)
-EVAL_PARAM(pc_bishop, 13)
-EVAL_PARAM(pc_rook, 17)
+EVAL_PARAM(pc_pawn, 1)
+EVAL_PARAM(pc_knight, 7)
+EVAL_PARAM(pc_bishop, 10)
+EVAL_PARAM(pc_rook, 16)
 EVAL_PARAM(pc_queen, 40)
-EVAL_PARAM(pc_intercept, -1)
+EVAL_PARAM(pc_intercept, 7)

--- a/includes/weights/ssc_middlegame.hpp
+++ b/includes/weights/ssc_middlegame.hpp
@@ -2,12 +2,11 @@
 
 # include "eval_param.hpp"
 
-EVAL_PARAM(ssc_mg_pawn, 63)
-EVAL_PARAM(ssc_mg_knight, 311)
-EVAL_PARAM(ssc_mg_bishop, 297)
-EVAL_PARAM(ssc_mg_rook, 372)
-EVAL_PARAM(ssc_mg_queen, 814)
-
+EVAL_PARAM(ssc_mg_pawn, 69)
+EVAL_PARAM(ssc_mg_knight, 304)
+EVAL_PARAM(ssc_mg_bishop, 291)
+EVAL_PARAM(ssc_mg_rook, 379)
+EVAL_PARAM(ssc_mg_queen, 845)
 EVAL_PARAM(ssc_mg_bishop_pair, 0)
 
 // All tables can be viewed from white's perspective with both kings on the kingside

--- a/includes/weights/ssc_middlegame.hpp
+++ b/includes/weights/ssc_middlegame.hpp
@@ -2,11 +2,12 @@
 
 # include "eval_param.hpp"
 
-EVAL_PARAM(ssc_mg_pawn, 69)
-EVAL_PARAM(ssc_mg_knight, 304)
-EVAL_PARAM(ssc_mg_bishop, 291)
-EVAL_PARAM(ssc_mg_rook, 379)
-EVAL_PARAM(ssc_mg_queen, 845)
+EVAL_PARAM(ssc_mg_pawn, 63)
+EVAL_PARAM(ssc_mg_knight, 311)
+EVAL_PARAM(ssc_mg_bishop, 297)
+EVAL_PARAM(ssc_mg_rook, 372)
+EVAL_PARAM(ssc_mg_queen, 814)
+
 EVAL_PARAM(ssc_mg_bishop_pair, 0)
 
 // All tables can be viewed from white's perspective with both kings on the kingside

--- a/includes/weights/ssc_middlegame.hpp
+++ b/includes/weights/ssc_middlegame.hpp
@@ -2,13 +2,12 @@
 
 # include "eval_param.hpp"
 
-EVAL_PARAM(ssc_mg_pawn, 63)
-EVAL_PARAM(ssc_mg_knight, 311)
-EVAL_PARAM(ssc_mg_bishop, 297)
-EVAL_PARAM(ssc_mg_rook, 372)
-EVAL_PARAM(ssc_mg_queen, 814)
-
-EVAL_PARAM(ssc_mg_bishop_pair, 0)
+EVAL_PARAM(ssc_mg_pawn, 71)
+EVAL_PARAM(ssc_mg_knight, 309)
+EVAL_PARAM(ssc_mg_bishop, 291)
+EVAL_PARAM(ssc_mg_rook, 396)
+EVAL_PARAM(ssc_mg_queen, 846)
+EVAL_PARAM(ssc_mg_bishop_pair, 5)
 
 // All tables can be viewed from white's perspective with both kings on the kingside
 

--- a/includes/weights/ssc_middlegame.hpp
+++ b/includes/weights/ssc_middlegame.hpp
@@ -8,6 +8,8 @@ EVAL_PARAM(ssc_mg_bishop, 297)
 EVAL_PARAM(ssc_mg_rook, 372)
 EVAL_PARAM(ssc_mg_queen, 814)
 
+EVAL_PARAM(ssc_mg_bishop_pair, 0)
+
 // All tables can be viewed from white's perspective with both kings on the kingside
 
 EVAL_PARAM_ARRAY(64, ssc_mg_pawn_table,

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -103,6 +103,7 @@ int maybe_remove_piece(Board &board, const Square square){
 		side.Bishop ^= mask;
 		side.All ^= mask;
 		board.EvalInfo.remove_bishop<white>(square);
+		if (__builtin_popcountll(side.Bishop) == 1) board.EvalInfo.remove_bishop_pair_bonus<white>();
 		attack.Bishop = bishop_attacks(side.Bishop, board.Occ ^ ToMask(get_side<not white>(board).King));
 		return 3;
 	case 4:
@@ -288,6 +289,7 @@ int make_move(Board &board, const Move move){
 		f.Bishop ^= ToMask(to);
 		f.All ^= move_mask;
 		board.EvalInfo.promote_pawn_to_bishop<white>(from, to);
+		if (__builtin_popcountll(f.Bishop) == 2) board.EvalInfo.remove_bishop_pair_bonus<not white>();
 		board.Occ = f.All | e.All;
 		capture = maybe_remove_piece<not white>(board, to);
 		f_atk.Pawn = pawn_attacks<white>(f.Pawn);

--- a/src/endgames.cpp
+++ b/src/endgames.cpp
@@ -9,9 +9,9 @@ inline bool only_has_minor(const HalfBoard &side){
 	return (not side.Rook) and (not side.Queen) and (__builtin_popcountll(side.Bishop | side.Knight) <= 1);
 }
 
-EVAL_PARAM(better_side_pawnless, 89)
-EVAL_PARAM(better_side_one_pawn, 174)
-EVAL_PARAM(better_side_two_pawn, 256)
+EVAL_PARAM(better_side_pawnless, 76)
+EVAL_PARAM(better_side_one_pawn, 159)
+EVAL_PARAM(better_side_two_pawn, 225)
 
 int make_endgame_adjustment(int raw_eval, const Board &board){
 	if ((not board.White.Pawn) and (raw_eval > 0)){

--- a/src/endgames.cpp
+++ b/src/endgames.cpp
@@ -11,6 +11,7 @@ inline bool only_has_minor(const HalfBoard &side){
 
 EVAL_PARAM(better_side_pawnless, 89)
 EVAL_PARAM(better_side_one_pawn, 174)
+EVAL_PARAM(better_side_two_pawn, 256)
 
 int make_endgame_adjustment(int raw_eval, const Board &board){
 	if ((not board.White.Pawn) and (raw_eval > 0)){
@@ -24,6 +25,9 @@ int make_endgame_adjustment(int raw_eval, const Board &board){
 	if ((__builtin_popcountll(board.White.Pawn) == 1) and (raw_eval > 0)){
 		return (raw_eval * better_side_one_pawn) / 256;
 	}
+	if ((__builtin_popcountll(board.White.Pawn) == 2) and (raw_eval > 0)){
+		return (raw_eval * better_side_two_pawn) / 256;
+	}
 
 	if ((not board.Black.Pawn) and (raw_eval < 0)){
 		if (only_has_minor(board.Black)){
@@ -35,6 +39,9 @@ int make_endgame_adjustment(int raw_eval, const Board &board){
 	}
 	if ((__builtin_popcountll(board.Black.Pawn) == 1) and (raw_eval < 0)){
 		return (raw_eval * better_side_one_pawn) / 256;
+	}
+	if ((__builtin_popcountll(board.Black.Pawn) == 2) and (raw_eval > 0)){
+		return (raw_eval * better_side_two_pawn) / 256;
 	}
 
 	return raw_eval;

--- a/src/endgames.cpp
+++ b/src/endgames.cpp
@@ -2,7 +2,7 @@
 # include "eval_param.hpp"
 
 bool is_insufficient_material(const Board &board){
-	return (not board.White.Pawn) and (not board.Black.Pawn) and ((board.EvalInfo.phase_count <= 4) or (board.EvalInfo.phase_count == 12));
+	return (not board.White.Pawn) and (not board.Black.Pawn) and ((board.EvalInfo.phase_count <= 9) or (board.EvalInfo.phase_count == 22));
 }
 
 inline bool only_has_minor(const HalfBoard &side){

--- a/src/endgames.cpp
+++ b/src/endgames.cpp
@@ -2,8 +2,7 @@
 # include "eval_param.hpp"
 
 bool is_insufficient_material(const Board &board){
-	return (not board.White.Pawn) and (not board.Black.Pawn) and 
-		((board.EvalInfo.phase_count <= 4) or (board.EvalInfo.phase_count == 12));
+	return (not board.White.Pawn) and (not board.Black.Pawn) and (board.EvalInfo.phase_count <= 17);
 }
 
 inline bool only_has_minor(const HalfBoard &side){
@@ -22,10 +21,10 @@ inline bool is_opposite_color_bishops(const Board &board){
 	return false;
 }
 
-EVAL_PARAM(better_side_pawnless, 89)
-EVAL_PARAM(better_side_one_pawn, 174)
-EVAL_PARAM(better_side_two_pawn, 256)
-EVAL_PARAM(ocb_endgame, 256)
+EVAL_PARAM(better_side_pawnless, 70)
+EVAL_PARAM(better_side_one_pawn, 156)
+EVAL_PARAM(better_side_two_pawn, 212)
+EVAL_PARAM(ocb_endgame, 203)
 
 int make_endgame_adjustment(int raw_eval, const Board &board){
 	if (is_opposite_color_bishops(board)) raw_eval = (raw_eval * ocb_endgame) / 256;

--- a/src/endgames.cpp
+++ b/src/endgames.cpp
@@ -2,47 +2,49 @@
 # include "eval_param.hpp"
 
 bool is_insufficient_material(const Board &board){
-	return (not board.White.Pawn) and (not board.Black.Pawn) and ((board.EvalInfo.phase_count <= 4) or (board.EvalInfo.phase_count == 12));
+	return (not board.White.Pawn) and (not board.Black.Pawn) and 
+		((board.EvalInfo.phase_count <= 4) or (board.EvalInfo.phase_count == 12));
 }
 
 inline bool only_has_minor(const HalfBoard &side){
 	return (not side.Rook) and (not side.Queen) and (__builtin_popcountll(side.Bishop | side.Knight) <= 1);
 }
 
+inline bool is_opposite_color_bishops(const Board &board){
+	if ((not board.White.Rook) and (not board.Black.Rook) and (not board.White.Knight) and (not board.Black.Knight) and
+		(not board.White.Queen) and (not board.Black.Queen)) {
+			int white_bishop_sign = ((board.White.Bishop & LIGHT_SQUARES) ? 1 : 0) 
+				- ((board.White.Bishop & DARK_SQUARES) ? 1 : 0);
+			int black_bishop_sign = ((board.Black.Bishop & LIGHT_SQUARES) ? 1 : 0) 
+				- ((board.Black.Bishop & DARK_SQUARES) ? 1 : 0);
+			return white_bishop_sign * black_bishop_sign == -1;
+		}
+	return false;
+}
+
 EVAL_PARAM(better_side_pawnless, 89)
 EVAL_PARAM(better_side_one_pawn, 174)
 EVAL_PARAM(better_side_two_pawn, 256)
+EVAL_PARAM(ocb_endgame, 256)
 
 int make_endgame_adjustment(int raw_eval, const Board &board){
-	if ((not board.White.Pawn) and (raw_eval > 0)){
-		if (only_has_minor(board.White)){
-			// White only has a single minor - checkmate can't be forced
-			return 0;
-		}
-		// White may be able to checkmate, but without pawns it's more difficult
-		return (raw_eval * better_side_pawnless) / 256;
+	if (is_opposite_color_bishops(board)) raw_eval = (raw_eval * ocb_endgame) / 256;
+
+	auto &better_side = (raw_eval > 0) ? board.White : board.Black;
+	int multiplier = 256;
+
+	if (not better_side.Pawn){
+		// Better side only has a single minor - checkmate can't be forced
+		if (only_has_minor(better_side)) multiplier = 0;
+		// Better side may be able to checkmate, but without pawns it's more difficult
+		else multiplier = better_side_pawnless;
 	}
-	if ((__builtin_popcountll(board.White.Pawn) == 1) and (raw_eval > 0)){
-		return (raw_eval * better_side_one_pawn) / 256;
+	if (__builtin_popcountll(better_side.Pawn) == 1){
+		multiplier = better_side_one_pawn;
 	}
-	if ((__builtin_popcountll(board.White.Pawn) == 2) and (raw_eval > 0)){
-		return (raw_eval * better_side_two_pawn) / 256;
+	if (__builtin_popcountll(better_side.Pawn) == 2){
+		multiplier = better_side_two_pawn;
 	}
 
-	if ((not board.Black.Pawn) and (raw_eval < 0)){
-		if (only_has_minor(board.Black)){
-			// Black only has a single minor - checkmate can't be forced
-			return 0;
-		}
-		// Black may be able to checkmate, but without pawns it's more difficult
-		return (raw_eval * better_side_pawnless) / 256;
-	}
-	if ((__builtin_popcountll(board.Black.Pawn) == 1) and (raw_eval < 0)){
-		return (raw_eval * better_side_one_pawn) / 256;
-	}
-	if ((__builtin_popcountll(board.Black.Pawn) == 2) and (raw_eval > 0)){
-		return (raw_eval * better_side_two_pawn) / 256;
-	}
-
-	return raw_eval;
+	return (raw_eval * multiplier) / 256;
 }

--- a/src/endgames.cpp
+++ b/src/endgames.cpp
@@ -9,9 +9,9 @@ inline bool only_has_minor(const HalfBoard &side){
 	return (not side.Rook) and (not side.Queen) and (__builtin_popcountll(side.Bishop | side.Knight) <= 1);
 }
 
-EVAL_PARAM(better_side_pawnless, 76)
-EVAL_PARAM(better_side_one_pawn, 159)
-EVAL_PARAM(better_side_two_pawn, 225)
+EVAL_PARAM(better_side_pawnless, 89)
+EVAL_PARAM(better_side_one_pawn, 174)
+EVAL_PARAM(better_side_two_pawn, 256)
 
 int make_endgame_adjustment(int raw_eval, const Board &board){
 	if ((not board.White.Pawn) and (raw_eval > 0)){

--- a/src/endgames.cpp
+++ b/src/endgames.cpp
@@ -2,7 +2,7 @@
 # include "eval_param.hpp"
 
 bool is_insufficient_material(const Board &board){
-	return (not board.White.Pawn) and (not board.Black.Pawn) and ((board.EvalInfo.phase_count <= 9) or (board.EvalInfo.phase_count == 22));
+	return (not board.White.Pawn) and (not board.Black.Pawn) and ((board.EvalInfo.phase_count <= 4) or (board.EvalInfo.phase_count == 12));
 }
 
 inline bool only_has_minor(const HalfBoard &side){

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -6,15 +6,15 @@
 
 EVAL_PARAM(mg_bishop_atk, 3)
 EVAL_PARAM(mg_rook_atk, 3)
-EVAL_PARAM(mg_queen_atk, 0)
-EVAL_PARAM(mg_tempo, 10)
+EVAL_PARAM(mg_queen_atk, -1)
+EVAL_PARAM(mg_tempo, 5)
 
 EVAL_PARAM(eg_bishop_atk, 4)
-EVAL_PARAM(eg_rook_atk, 3)
-EVAL_PARAM(eg_queen_atk, 3)
-EVAL_PARAM(eg_tempo, -3)
+EVAL_PARAM(eg_rook_atk, 4)
+EVAL_PARAM(eg_queen_atk, 5)
+EVAL_PARAM(eg_tempo, -1)
 
-EVAL_PARAM(eval_divisor, 284)
+EVAL_PARAM(eval_divisor, 256)
 
 template <bool wtm>
 int eval(const Board &board)

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -6,15 +6,15 @@
 
 EVAL_PARAM(mg_bishop_atk, 3)
 EVAL_PARAM(mg_rook_atk, 3)
-EVAL_PARAM(mg_queen_atk, -1)
-EVAL_PARAM(mg_tempo, 5)
+EVAL_PARAM(mg_queen_atk, 0)
+EVAL_PARAM(mg_tempo, 10)
 
 EVAL_PARAM(eg_bishop_atk, 4)
-EVAL_PARAM(eg_rook_atk, 4)
-EVAL_PARAM(eg_queen_atk, 5)
-EVAL_PARAM(eg_tempo, -1)
+EVAL_PARAM(eg_rook_atk, 3)
+EVAL_PARAM(eg_queen_atk, 3)
+EVAL_PARAM(eg_tempo, -3)
 
-EVAL_PARAM(eval_divisor, 256)
+EVAL_PARAM(eval_divisor, 284)
 
 template <bool wtm>
 int eval(const Board &board)

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -14,6 +14,7 @@ EVAL_PARAM(eg_rook_atk, 4)
 EVAL_PARAM(eg_queen_atk, 5)
 EVAL_PARAM(eg_tempo, -1)
 
+EVAL_PARAM(eval_divisor, 256)
 
 template <bool wtm>
 int eval(const Board &board)
@@ -32,7 +33,7 @@ int eval(const Board &board)
 	const int eg_eval = info.eg + eg_bishop_atk * bishop_atk_cnt + eg_rook_atk * rook_atk_cnt + eg_queen_atk * queen_atk_cnt + eg_tempo * sign;
     const int raw_eval = eg_eval * 256 + info.phase_count * (mg_eval - eg_eval);
 
-    return sign * make_endgame_adjustment(raw_eval, board) / 256;
+    return sign * make_endgame_adjustment(raw_eval, board) / eval_divisor;
 }
 
 template int eval<true>(const Board&);

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -7,14 +7,12 @@
 EVAL_PARAM(mg_bishop_atk, 3)
 EVAL_PARAM(mg_rook_atk, 3)
 EVAL_PARAM(mg_queen_atk, -1)
-EVAL_PARAM(mg_tempo, 5)
-
-EVAL_PARAM(eg_bishop_atk, 4)
+EVAL_PARAM(mg_tempo, 8)
+EVAL_PARAM(eg_bishop_atk, 6)
 EVAL_PARAM(eg_rook_atk, 4)
 EVAL_PARAM(eg_queen_atk, 5)
-EVAL_PARAM(eg_tempo, -1)
-
-EVAL_PARAM(eval_divisor, 256)
+EVAL_PARAM(eg_tempo, -3)
+EVAL_PARAM(eval_divisor, 285)
 
 template <bool wtm>
 int eval(const Board &board)

--- a/src/pst.cpp
+++ b/src/pst.cpp
@@ -75,6 +75,14 @@ PstEvalInfo static_eval_info(
 
 	if (castle & ToMask(white ? A1 : A8)){ hash ^= (white ? white_cqs_hash : black_cqs_hash); }
 	if (castle & ToMask(white ? H1 : H8)){ hash ^= (white ? white_cks_hash : black_cks_hash); }
+
+	if (__builtin_popcountll(bishop) > 1){
+		mg_kk += ssc_mg_bishop_pair;
+		mg_qk += osc_mg_bishop_pair;
+		mg_kq += osc_mg_bishop_pair;
+		mg_qq += ssc_mg_bishop_pair;
+		eg += eg_bishop_pair;
+	}
     
     return PstEvalInfo{mg_kk, mg_qk, mg_kq, mg_qq, eg, phase_count, hash};
 }
@@ -171,3 +179,15 @@ void PstEvalInfo::castle_kingside(){
 }
 template void PstEvalInfo::castle_kingside<true>();
 template void PstEvalInfo::castle_kingside<false>();
+
+template <bool white>
+void PstEvalInfo::remove_bishop_pair_bonus(){
+	auto sign = white ? 1 : -1;
+	mg_kk -= ssc_mg_bishop_pair * sign;
+	mg_qk -= osc_mg_bishop_pair * sign;
+	mg_kq -= osc_mg_bishop_pair * sign;
+	mg_qq -= ssc_mg_bishop_pair * sign;
+	eg -= eg_bishop_pair * sign;
+}
+template void PstEvalInfo::remove_bishop_pair_bonus<true>();
+template void PstEvalInfo::remove_bishop_pair_bonus<false>();


### PR DESCRIPTION
A few things here:
- Add a bonus for the bishop pair, particularly in the endgame
- Shrink the evaluation towards zero when the better side has two pawns
- Shrink the evaluation towards zero in OCB endgames
- Texel tune all non-array evaluation parameters

Looks like this gains about 18 elo:
```
                              Score  T-Stat    Win   Draw   Loss   Elo
bishop-pair                   747.5    3.20  487.0  521.0  392.0  18.0
aspiration-windows            717.0    1.16  446.0  542.0  412.0   5.0
tune-tables                   706.0    0.39  488.0  436.0  476.0   0.0
main                          705.5    0.37  450.0  511.0  439.0   0.0
tune-move-order               695.5   -0.31  422.0  547.0  431.0  -4.0
lmr-4                         693.5   -0.44  424.0  539.0  437.0  -5.0
use-32nd-of-time              677.0   -1.57  404.0  546.0  450.0 -12.0
internal-iterative-deepening  658.0   -2.84  394.0  528.0  478.0 -21.0
```