### PR TITLE
Mop up

### DIFF
--- a/src/endgames.cpp
+++ b/src/endgames.cpp
@@ -47,3 +47,93 @@ int make_endgame_adjustment(int raw_eval, const Board &board){
 
 	return (raw_eval * multiplier) / 256;
 }
+
+// These are chosen such that 5-piece pawnless endgames have the right result
+// Drawn endgames: KNNvK=120, KRvKN=120, KQvKRN=110
+// Won endgames: KRNvKB=140, KBBvKN=140, KQvKBB=150, KBNvK=160, KQvKR=170
+// Linear programming confirms that the margin of 7/6 is optimal
+// The choice of queen can vary from 340 to 360 keeping the same margin
+const int mop_up_knight = 60;
+const int mop_up_bishop = 100;
+const int mop_up_rook = 180;
+const int mop_up_queen = 350;
+
+// Force the king to the edge of the board to checkmate
+// With pawns off the board, the regular pst is no good anymore - we need more symmetry!
+const std::array<int, 64> mop_up_king_pst = {
+	18, 15, 12,  9,  9, 12, 15, 18,
+	15, 12,  9,  6,  6,  9, 12, 15,
+	12,  9,  6,  3,  3,  6,  9, 12,
+	 9,  6,  3,  0,  0,  3,  6,  9,
+	 9,  6,  3,  0,  0,  3,  6,  9,
+	12,  9,  6,  3,  3,  6,  9, 12,
+	15, 12,  9,  6,  6,  9, 12, 15,
+	18, 15, 12,  9,  9, 12, 15, 18,
+};
+
+// For handling KBNvK (drive king into corner controlled by bishop)
+// Also can help defent KRvKB (keep king out of corner controlled by bishop)
+const std::array<int, 64> mop_up_king_pst_lsb = {
+	 6,  7,  8,  9, 11, 14, 17, 20,
+	 7,  4,  5,  6,  8, 11, 14, 17,
+	 8,  5,  2,  3,  5,  8, 11, 14,
+	 9,  6,  3,  0,  2,  5,  8, 11,
+	11,  8,  5,  2,  0,  3,  6,  9,
+	14, 11,  8,  5,  3,  2,  5,  8,
+	17, 14, 11,  8,  6,  5,  4,  7,
+	20, 17, 14, 11,  9,  8,  7,  6,
+};
+const std::array<int, 64> mop_up_king_pst_dsb = {
+	20, 17, 14, 11,  9,  8,  7,  6,
+	17, 14, 11,  8,  6,  5,  4,  7,
+	14, 11,  8,  5,  3,  2,  5,  8,
+	11,  8,  5,  2,  0,  3,  6,  9,
+	 9,  6,  3,  0,  2,  5,  8, 11,
+	 8,  5,  2,  3,  5,  8, 11, 14,
+	 7,  4,  5,  6,  8, 11, 14, 17,
+	 6,  7,  8,  9, 11, 14, 17, 20,
+};
+
+// We need to bring our king in close to assist with the checkmate
+int manhattan_distance(const Square k1, const Square k2){
+	return std::abs(k1 % 8 - k2 % 8) + std::abs(k1 / 8 - k2 / 8);
+}
+
+std::array<int, 64> relevant_mop_up_pst(const Board &board){
+	if (__builtin_popcountll(board.White.Bishop | board.Black.Bishop) != 1) return mop_up_king_pst;
+	if (__builtin_popcountll(board.Occ) == 4) {
+		// If it's KRvKB, the king should avoid the square the bishop controls
+		// If it's KBNvK, the attacker should drive the king to the square the bishop controls
+		// Other 4-man endgames with 1 bishop are too far from the margin for this to make a difference
+		return ((board.White.Bishop | board.Black.Bishop) & LIGHT_SQUARES) ? mop_up_king_pst_lsb : mop_up_king_pst_dsb;
+	}
+	if (__builtin_popcountll(board.Occ) == 5) {
+		if ((board.White.Queen | board.Black.Queen) and (board.White.Knight | board.Black.Knight)) {
+			// The only relevant one here is KQvKBN which is generally a win
+			// The attacker must avoid a drawing fortress in the corner the bishop controls
+			return ((board.White.Bishop | board.Black.Bishop) & LIGHT_SQUARES) ? mop_up_king_pst_dsb : mop_up_king_pst_lsb;
+		}
+	}
+	return mop_up_king_pst;
+}
+
+// Inspired by this: https://www.chessprogramming.org/Mop-up_Evaluation#Chess_4.x
+int mop_up_evaluation(const Board &board){
+	const int material_imbalance
+		= __builtin_popcountll(board.White.Knight) * mop_up_knight
+		+ __builtin_popcountll(board.White.Bishop) * mop_up_bishop
+		+ __builtin_popcountll(board.White.Rook) * mop_up_rook
+		+ __builtin_popcountll(board.White.Queen) * mop_up_queen
+		- __builtin_popcountll(board.Black.Knight) * mop_up_knight
+		- __builtin_popcountll(board.Black.Bishop) * mop_up_bishop
+		- __builtin_popcountll(board.Black.Rook) * mop_up_rook
+		- __builtin_popcountll(board.Black.Queen) * mop_up_queen;
+	
+	const int king_distance = manhattan_distance(board.White.King, board.Black.King);
+
+	auto pst = relevant_mop_up_pst(board);
+
+	return material_imbalance
+		+ (material_imbalance > 0) * (pst[board.Black.King] - king_distance - 2 * __builtin_popcountll(EDGES & board.White.All))
+		- (material_imbalance < 0) * (pst[board.White.King] - king_distance - 2 * __builtin_popcountll(EDGES & board.Black.All));
+}

--- a/src/endgames.cpp
+++ b/src/endgames.cpp
@@ -134,6 +134,8 @@ int mop_up_evaluation(const Board &board){
 	auto pst = relevant_mop_up_pst(board);
 
 	return material_imbalance
-		+ (material_imbalance > 0) * (pst[board.Black.King] - king_distance - 2 * __builtin_popcountll(EDGES & board.White.All))
-		- (material_imbalance < 0) * (pst[board.White.King] - king_distance - 2 * __builtin_popcountll(EDGES & board.Black.All));
+		+ (material_imbalance > 0) * (pst[board.Black.King] - king_distance)
+		- (material_imbalance < 0) * (pst[board.White.King] - king_distance)
+		- __builtin_popcountll(EDGES & board.White.All)
+		+ __builtin_popcountll(EDGES & board.Black.All);
 }

--- a/src/endgames.hpp
+++ b/src/endgames.hpp
@@ -2,3 +2,4 @@
 
 bool is_insufficient_material(const Board &board);
 int make_endgame_adjustment(int raw_eval, const Board &board);
+int mop_up_evaluation(const Board &board);

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -18,6 +18,7 @@ template <bool wtm>
 int eval(const Board &board)
 {
 	const int sign = wtm ? 1 : -1;
+	if ((not board.White.Pawn) and (not board.Black.Pawn)) return mop_up_evaluation(board) * sign;
 
 	const auto &info = board.EvalInfo;
 	const int bishop_atk_cnt = __builtin_popcountll(board.WtAtk.Bishop) - __builtin_popcountll(board.BkAtk.Bishop);


### PR DESCRIPTION
With this PR, Rengar scores 100% on KQvK, KRvK, KBBvK, KQvKN, and KQvKB. The scores on the others:
- KBNvK: 21%
- KQvKR: 78%
- KQvKBN: 89%
- KNNNvK: 94%

KBNvK goes over 50% at higher depths