### PR TITLE
Fix time management bug

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -234,7 +234,7 @@ std::tuple<Move, int> search_for_move_w_eval(const Board &board, History &histor
 	try {
 		bool should_increment_depth = false;
 		int aspiration_window_radius = 200;
-		while ((ms_elapsed < min_time_ms) and 
+		while ((ms_elapsed < min_time_ms or depth < 4) and 
 			(not should_increment_depth or ((eval > CHECKMATED) and (eval < -CHECKMATED) and (depth < depth_limit)))){
 			if (should_increment_depth) depth++;
 			int new_eval = eval;

--- a/src/unittest/search_test.cpp
+++ b/src/unittest/search_test.cpp
@@ -41,3 +41,13 @@ TEST_CASE("Hash table pathology repro"){
     auto move2 = search_for_move<false>(board, history, INT_MAX, 7, INT_MAX, INT_MAX);
     CHECK(move2 == move_from_squares(B7, B5, DOUBLE_PAWN_PUSH));
 }
+
+TEST_CASE("Play obvious move with zero time"){
+    Board board;
+    parse_fen("6k1/8/8/8/8/8/5qPP/6K1 w - - 0 1", board);
+    History history;
+    ht_init(12);
+    initialize_move_order_arrays();
+    auto move = search_for_move<true>(board, history, INT_MAX, max_var_length, 0, 0);
+    CHECK(move == move_from_squares(G1, F2, KING_MOVE));
+}


### PR DESCRIPTION
If Rengar is asked for a move with 33 milliseconds or less on the clock, it would previously skip the deepening loop and play some move interpreted from uninitialized garbage. In practice, I observed this to be the last move Rengar played. Now we search to depth at least 4 provided the search time stays under a millisecond. 

This only matters for games played without increment. H/t to Lars for flagging the underperformance in such games. 