### PR TITLE
Improvements to history tracking and 50-move rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,9 @@ analysis/*.db
 .vscode/
 cutechess-cli
 rengar_venv/
-*.rg
-*.rg.*.csv
+/selfplay_data/*.rg
+/selfplay_data/*.rg.csv
+/selfplay_data/*.parquet
 /chess324_openings
 /classical_eval.csv
 /networks/*.pt

--- a/all_mate_tests.sh
+++ b/all_mate_tests.sh
@@ -1,1 +1,1 @@
-for x in mate_test_fens/*.txt; do y=${x%.txt} && ./matetest ${y##*/} 6; done
+for x in mate_test_fens/*.txt; do y=${x%.txt} && ./matetest ${y##*/} 10; done

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -49,11 +49,17 @@ ForwardPassOutput forward_pass(const Board &board){
 	return ForwardPassOutput{l1, l2, eval_};
 }
 
+bool mop_up_mode_active = false;
+void set_mop_up_mode(const bool activate_mop_up_mode) {
+	mop_up_mode_active = activate_mop_up_mode;
+}
+
+
 template <bool wtm>
 int eval(const Board &board)
 {
 	const int sign = wtm ? 1 : -1;
-	if ((not board.White.Pawn) and (not board.Black.Pawn)) return mop_up_evaluation(board) * sign;
+	if (mop_up_mode_active) return mop_up_evaluation(board) * sign;
 	const int result = forward_pass<wtm>(board).eval;
 	if (only_has_minor(result >= 0 ? board.White : board.Black)) return 0;
 	return sign * result;

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -53,6 +53,7 @@ bool mop_up_mode_active = false;
 void set_mop_up_mode(const bool activate_mop_up_mode) {
 	mop_up_mode_active = activate_mop_up_mode;
 }
+bool is_mop_up_mode(){ return mop_up_mode_active; }
 
 
 template <bool wtm>

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -22,3 +22,4 @@ template <bool wtm>
 int eval(const Board &board);
 
 void set_mop_up_mode(const bool activate_mop_up_mode);
+bool is_mop_up_mode();

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -20,3 +20,5 @@ ForwardPassOutput forward_pass(const Board &board);
 
 template <bool wtm>
 int eval(const Board &board);
+
+void set_mop_up_mode(const bool activate_mop_up_mode);

--- a/src/hashing.hpp
+++ b/src/hashing.hpp
@@ -157,3 +157,16 @@ const std::array black_piece_hashes = {
 	black_pawn_hash, black_knight_hash, black_bishop_hash, 
 	black_rook_hash, black_queen_hash, black_king_hash,
 };
+
+const std::array<uint64_t, 100> halfmove_clock_hash = {
+		get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), 
+		get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), 
+		get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), 
+		get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), 
+		get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), 
+		get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), 
+		get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), 
+		get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), 
+		get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), 
+		get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), 
+};

--- a/src/hashing.hpp
+++ b/src/hashing.hpp
@@ -170,3 +170,4 @@ const std::array<uint64_t, 100> halfmove_clock_hash = {
 		get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), 
 		get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), get_rand(), 
 };
+const uint64_t mop_up_hash = get_rand();

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1,27 +1,37 @@
 # include "history.hpp"
 
-int History::index_of_repetition(const uint64_t hash) const{
+int HistoryView::index_of_repetition(const uint64_t hash) const{
 	bool twofold = false;
 	for (int idx = curr_idx - 4; idx >= irreversible_idx; idx -= 2){
-		if (hash_array[idx] == hash){
-			if (twofold or (idx >= root_idx)) return idx;
+		if (history.hash_array[idx] == hash){
+			if (twofold or (idx >= history.root_idx)) return idx;
 			twofold = true;
 		}
 	}
 	return -1;
 }
-History History::extend(const uint64_t hash){
-	hash_array[curr_idx] = hash;
-	return History{hash_array, curr_idx + 1, root_idx, irreversible_idx};
+HistoryView HistoryView::extend(const uint64_t hash){
+	history.hash_array[curr_idx] = hash;
+	return HistoryView{history, curr_idx + 1, irreversible_idx};
 }
-History History::make_irreversible() const{
-	return History{hash_array, curr_idx + 1, root_idx, curr_idx + 1};
+HistoryView HistoryView::make_irreversible() const{
+	return HistoryView{history, curr_idx + 1, curr_idx + 1};
+}
+void HistoryView::operator=(HistoryView hv){
+	this->history = hv.history;
+	this->curr_idx = hv.curr_idx;
+	this->irreversible_idx = hv.irreversible_idx;
 }
 
-History History::wipe(){
-	return History{hash_array, 0, 0, 0};
+
+void History::wipe(){
+	root_idx = 0;
 }
-History History::extend_root(const uint64_t hash){
-	hash_array[curr_idx] = hash;
-	return History{hash_array, curr_idx + 1, curr_idx + 1, irreversible_idx};
+void History::extend_root(const uint64_t hash){
+	hash_array[root_idx] = hash;
+	root_idx++;
+}
+
+HistoryView take_view(History &history){
+	return HistoryView{history, history.root_idx, 0};
 }

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1,6 +1,6 @@
 # include "history.hpp"
 
-int HistoryView::index_of_repetition(const uint64_t hash, bool twofold = false) const{
+int HistoryView::index_of_repetition(const uint64_t hash, bool twofold) const{
 	for (int idx = curr_idx - 4; idx >= irreversible_idx; idx -= 2){
 		if (history.hash_array[idx] == hash){
 			if (twofold or (idx >= history.root_idx)) return idx;

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1,7 +1,6 @@
 # include "history.hpp"
 
-int HistoryView::index_of_repetition(const uint64_t hash) const{
-	bool twofold = false;
+int HistoryView::index_of_repetition(const uint64_t hash, bool twofold = false) const{
 	for (int idx = curr_idx - 4; idx >= irreversible_idx; idx -= 2){
 		if (history.hash_array[idx] == hash){
 			if (twofold or (idx >= history.root_idx)) return idx;

--- a/src/history.hpp
+++ b/src/history.hpp
@@ -17,7 +17,7 @@ struct HistoryView{
 	int curr_idx;
 	int irreversible_idx;
 
-	int index_of_repetition(const uint64_t hash, bool twofold = false) const;
+	int index_of_repetition(const uint64_t hash, bool twofold) const;
 	HistoryView extend(const uint64_t hash);
 	HistoryView make_irreversible() const;
 

--- a/src/history.hpp
+++ b/src/history.hpp
@@ -17,7 +17,7 @@ struct HistoryView{
 	int curr_idx;
 	int irreversible_idx;
 
-	int index_of_repetition(const uint64_t hash) const;
+	int index_of_repetition(const uint64_t hash, bool twofold = false) const;
 	HistoryView extend(const uint64_t hash);
 	HistoryView make_irreversible() const;
 

--- a/src/history.hpp
+++ b/src/history.hpp
@@ -5,15 +5,24 @@
 
 struct History{
 	std::array<uint64_t, 256> hash_array;
-
-	int curr_idx = 0;
 	int root_idx = 0;
-	int irreversible_idx = 0;
+
+	void wipe();
+	void extend_root(const uint64_t hash);
+};
+
+
+struct HistoryView{
+	History &history;
+	int curr_idx;
+	int irreversible_idx;
 
 	int index_of_repetition(const uint64_t hash) const;
-	History extend(const uint64_t hash);
-	History make_irreversible() const;
+	HistoryView extend(const uint64_t hash);
+	HistoryView make_irreversible() const;
 
-	History wipe();
-	History extend_root(const uint64_t hash);
+	void operator=(HistoryView hv);
 };
+
+
+HistoryView take_view(History &history);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -114,6 +114,8 @@ std::tuple<int, VariationView, int> search_helper(const Board &board, const int 
 	}
 
 	const auto hash_key = board.ue.hash ^ (white ? wtm_hash : 0) ^ 
+		// Clear the hash when we enter mop-up mode to avoid scores from non-mop-up eval which has a different level
+		(is_mop_up_mode() ? mop_up_hash : 0) ^
 		// Clear the hash if we've started halving the eval or we'll get a lot of misleading scores from the hash table
 		((encourage_progress and history.irreversible_idx == 0) ? halfmove_clock_hash[encourage_progress_after] : 0) ^
 		// If nearing the 50-move-rule limit, a position's score may change based on how many moves we have to make progress

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -73,7 +73,7 @@ int search_extension(const Board &board, const int alpha, const int beta){
 int _global_node_limit = INT_MAX;
 struct NodeLimitSafety{};
 
-const int encourage_progress_after = 40;
+const int encourage_progress_after = 20;
 const int force_progress_after = 90;
 bool encourage_progress = false;
 bool force_progress = false;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -90,8 +90,7 @@ std::tuple<int, VariationView, int> search_helper(const Board &board, const int 
 		return std::make_tuple(0, last_pv.nullify(), index_of_repetition); 
 	}
 	// Draw by fifty move rule
-	if ((history.irreversible_idx == 0) and (history.curr_idx == 100)) {
-		fifty_move_rule_relevant = true;
+	if (fifty_move_rule_relevant and (history.irreversible_idx == 0) and (history.curr_idx == 100)) {
 		return std::make_tuple(0, last_pv.nullify(), history.curr_idx);
 	}
 
@@ -239,7 +238,7 @@ std::tuple<Move, int> search_for_move_w_eval(const Board &board, History &histor
 	VariationWorkspace workspace;
 	VariationView var = VariationView(workspace);
 	HistoryView hv = take_view(history);
-	fifty_move_rule_relevant = false;
+	fifty_move_rule_relevant = history.root_idx > 80;
 
 	int depth = 1;
 	int eval = 0;

--- a/src/selfplay/adjudication.cpp
+++ b/src/selfplay/adjudication.cpp
@@ -2,13 +2,13 @@
 # include "../endgames.hpp"
 # include "../movegen.hpp"
 
-char adjuicate_game(const Board &board, bool wtm, const History &history){
+char adjuicate_game(const Board &board, bool wtm, const HistoryView &history){
     // Insufficient material -> draw
     if (is_insufficient_material(board)) return 'D';
     // Fifty move rule -> draw
     if (history.curr_idx - history.irreversible_idx >= 100) return 'D';
     // Threefold repetition -> draw
-    if (history.index_of_repetition(board.ue.hash) != -1) return 'D';
+    if (history.index_of_repetition(board.ue.hash, false) != -1) return 'D';
 
     auto cnp = (wtm ? checks_and_pins<true> : checks_and_pins<false>)(board);
     auto queue = (wtm ? generate_moves<true> : generate_moves<false>)(board, cnp, 0, 0, 0);

--- a/src/selfplay/adjudication.hpp
+++ b/src/selfplay/adjudication.hpp
@@ -1,4 +1,4 @@
 # include "../board.hpp"
 # include "../history.hpp"
 
-char adjuicate_game(const Board &board, bool wtm, const History &history);
+char adjuicate_game(const Board &board, bool wtm, const HistoryView &history);

--- a/src/selfplay/selfplay.cpp
+++ b/src/selfplay/selfplay.cpp
@@ -19,19 +19,19 @@ GameData run_selfplay(const Board &starting_board, const GameData book_line, int
         moves.push_back(book_move);
     }
 
-    char result = adjuicate_game(game_board, wtm, history);
+    char result = adjuicate_game(game_board, wtm, take_view(history));
     while (result == 'U') {
         Move search_move = (wtm ? search_for_move<true> : search_for_move<false>)
             (game_board, history, INT_MAX, search_depth, INT_MAX, INT_MAX);
         if (is_irreversible(game_board, search_move)){
-            history = history.wipe();
+            history.wipe();
         } else {
-            history = history.extend_root(game_board.ue.hash);
+            history.extend_root(game_board.ue.hash);
         }
         (wtm ? make_move<true> : make_move<false>)(game_board, search_move);
         wtm = not wtm;
         moves.push_back(search_move);
-        result = adjuicate_game(game_board, wtm, history);
+        result = adjuicate_game(game_board, wtm, take_view(history));
     }
 
     return GameData{moves, result};

--- a/src/uci/main.cpp
+++ b/src/uci/main.cpp
@@ -138,18 +138,27 @@ int main() {
 			std::string postype;
 			std::getline(input_stream, postype, ' ');
 			std::string fen;
+			int halfmove_clock = 0;
 			if (postype == "startpos"){
 				fen = STARTING_FEN;
 			} else if (postype == "fen"){
 				fen = "";
-				for (int i = 0; i < 6; i++){
+				for (int i = 0; i < 4; i++){
 					std::string fen_chunk;
 					std::getline(input_stream, fen_chunk, ' ');
 					fen = fen + (i == 0 ? "" : " ") + fen_chunk;
 				}
+				input_stream >> halfmove_clock;
+				// This is a terrible way to get the "moves" command parsed
+				// This will parse the space after the halfmove clock...
+				std::getline(input_stream, command, ' ');
+				// ...this will parse the fullmove clock...
+				std::getline(input_stream, command, ' ');
+				// ...and teh line below will get the "moves" command
 			}
 			wtm = parse_fen(fen, board);
 			history.wipe();
+			for (int i = 0; i < halfmove_clock; i++) history.extend_root(0ull);
 
 			std::getline(input_stream, command, ' ');
 		}

--- a/src/uci/main.cpp
+++ b/src/uci/main.cpp
@@ -149,7 +149,7 @@ int main() {
 				}
 			}
 			wtm = parse_fen(fen, board);
-			history = history.wipe();
+			history.wipe();
 
 			std::getline(input_stream, command, ' ');
 		}
@@ -157,9 +157,9 @@ int main() {
 			for (std::string move_text; std::getline(input_stream, move_text, ' ');){
 				Move move = parse_move_xboard(move_text, board, wtm);
 				if (is_irreversible(board, move)){
-					history = history.wipe();
+					history.wipe();
 				} else {
-					history = history.extend_root(board.ue.hash);
+					history.extend_root(board.ue.hash);
 				}
 				(wtm ? make_move<true> : make_move<false>) (board, move);
 				wtm = !wtm;

--- a/src/unittest/history_test.cpp
+++ b/src/unittest/history_test.cpp
@@ -4,59 +4,85 @@
 # include "../history.hpp"
 
 
-TEST_CASE("Repetition checking"){
+TEST_CASE("Repetition checking from root"){
 	Board board;
 	parse_fen("8/1p6/1P5p/3Rr2k/p3r1q1/3Q2P1/5B2/6K1 b - - 3 49", board);
 	History root_history;
-	History search_history;
-	CHECK(-1 == root_history.index_of_repetition(board.ue.hash));
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+
+	root_history.extend_root(board.ue.hash);
+	make_move<false>(board, move_from_squares(G4, F5, QUEEN_MOVE));
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+
+	root_history.extend_root(board.ue.hash);
+	make_move<true>(board, move_from_squares(D3, D1, QUEEN_MOVE));
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+
+	root_history.extend_root(board.ue.hash);
+	make_move<false>(board, move_from_squares(F5, G4, QUEEN_MOVE));
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+
+	root_history.extend_root(board.ue.hash);
+	make_move<true>(board, move_from_squares(D1, D3, QUEEN_MOVE));
+	// Two-fold, but no game-ending repetition
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+
+	root_history.extend_root(board.ue.hash);
+	make_move<false>(board, move_from_squares(E5, F5, ROOK_MOVE));
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+
+	root_history.extend_root(board.ue.hash);
+	make_move<true>(board, move_from_squares(G1, F1, KING_MOVE));
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+
+	root_history.extend_root(board.ue.hash);
+	make_move<false>(board, move_from_squares(F5, E5, ROOK_MOVE));
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+
+	root_history.extend_root(board.ue.hash);
+	make_move<true>(board, move_from_squares(F1, G1, KING_MOVE));
+	// Threefold repetition, ending the game
+	CHECK(0 == take_view(root_history).index_of_repetition(board.ue.hash));
+}
+
+TEST_CASE("Repetition checking in search"){
+	Board board;
+	parse_fen("8/1p6/1P5p/3Rr2k/p3r1q1/3Q2P1/5B2/6K1 b - - 3 49", board);
+	History root_history;
+	HistoryView search_history = take_view(root_history);
 	CHECK(-1 == search_history.index_of_repetition(board.ue.hash));
 
-	root_history = root_history.extend_root(board.ue.hash);
 	search_history = search_history.extend(board.ue.hash);
 	make_move<false>(board, move_from_squares(G4, F5, QUEEN_MOVE));
-	CHECK(-1 == root_history.index_of_repetition(board.ue.hash));
 	CHECK(-1 == search_history.index_of_repetition(board.ue.hash));
 
-	root_history = root_history.extend_root(board.ue.hash);
 	search_history = search_history.extend(board.ue.hash);
 	make_move<true>(board, move_from_squares(D3, D1, QUEEN_MOVE));
-	CHECK(-1 == root_history.index_of_repetition(board.ue.hash));
 	CHECK(-1 == search_history.index_of_repetition(board.ue.hash));
 
-	root_history = root_history.extend_root(board.ue.hash);
 	search_history = search_history.extend(board.ue.hash);
 	make_move<false>(board, move_from_squares(F5, G4, QUEEN_MOVE));
-	CHECK(-1 == root_history.index_of_repetition(board.ue.hash));
 	CHECK(-1 == search_history.index_of_repetition(board.ue.hash));
 
-	root_history = root_history.extend_root(board.ue.hash);
 	search_history = search_history.extend(board.ue.hash);
 	make_move<true>(board, move_from_squares(D1, D3, QUEEN_MOVE));
-	CHECK(-1 == root_history.index_of_repetition(board.ue.hash));
+	// Two-fold which we identify as a draw in search
 	CHECK(0 == search_history.index_of_repetition(board.ue.hash));
 
-	root_history = root_history.extend_root(board.ue.hash);
 	search_history = search_history.extend(board.ue.hash);
 	make_move<false>(board, move_from_squares(E5, F5, ROOK_MOVE));
-	CHECK(-1 == root_history.index_of_repetition(board.ue.hash));
 	CHECK(-1 == search_history.index_of_repetition(board.ue.hash));
 
-	root_history = root_history.extend_root(board.ue.hash);
 	search_history = search_history.extend(board.ue.hash);
 	make_move<true>(board, move_from_squares(G1, F1, KING_MOVE));
-	CHECK(-1 == root_history.index_of_repetition(board.ue.hash));
 	CHECK(-1 == search_history.index_of_repetition(board.ue.hash));
 
-	root_history = root_history.extend_root(board.ue.hash);
 	search_history = search_history.extend(board.ue.hash);
 	make_move<false>(board, move_from_squares(F5, E5, ROOK_MOVE));
-	CHECK(-1 == root_history.index_of_repetition(board.ue.hash));
 	CHECK(-1 == search_history.index_of_repetition(board.ue.hash));
 
-	root_history = root_history.extend_root(board.ue.hash);
 	search_history = search_history.extend(board.ue.hash);
 	make_move<true>(board, move_from_squares(F1, G1, KING_MOVE));
-	CHECK(0 == root_history.index_of_repetition(board.ue.hash));
+	// Threefold. When searching for repetition, we first find the one at ply 4
 	CHECK(4 == search_history.index_of_repetition(board.ue.hash));
 }

--- a/src/unittest/history_test.cpp
+++ b/src/unittest/history_test.cpp
@@ -8,41 +8,43 @@ TEST_CASE("Repetition checking from root"){
 	Board board;
 	parse_fen("8/1p6/1P5p/3Rr2k/p3r1q1/3Q2P1/5B2/6K1 b - - 3 49", board);
 	History root_history;
-	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash, true));
 
 	root_history.extend_root(board.ue.hash);
 	make_move<false>(board, move_from_squares(G4, F5, QUEEN_MOVE));
-	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash, true));
 
 	root_history.extend_root(board.ue.hash);
 	make_move<true>(board, move_from_squares(D3, D1, QUEEN_MOVE));
-	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash, true));
 
 	root_history.extend_root(board.ue.hash);
 	make_move<false>(board, move_from_squares(F5, G4, QUEEN_MOVE));
-	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash, true));
 
 	root_history.extend_root(board.ue.hash);
 	make_move<true>(board, move_from_squares(D1, D3, QUEEN_MOVE));
 	// Two-fold, but no game-ending repetition
-	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash, false));
+	CHECK(0 == take_view(root_history).index_of_repetition(board.ue.hash, true));
 
 	root_history.extend_root(board.ue.hash);
 	make_move<false>(board, move_from_squares(E5, F5, ROOK_MOVE));
-	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash, true));
 
 	root_history.extend_root(board.ue.hash);
 	make_move<true>(board, move_from_squares(G1, F1, KING_MOVE));
-	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash, true));
 
 	root_history.extend_root(board.ue.hash);
 	make_move<false>(board, move_from_squares(F5, E5, ROOK_MOVE));
-	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash));
+	CHECK(-1 == take_view(root_history).index_of_repetition(board.ue.hash, true));
 
 	root_history.extend_root(board.ue.hash);
 	make_move<true>(board, move_from_squares(F1, G1, KING_MOVE));
 	// Threefold repetition, ending the game
-	CHECK(0 == take_view(root_history).index_of_repetition(board.ue.hash));
+	CHECK(0 == take_view(root_history).index_of_repetition(board.ue.hash, false));
+	CHECK(4 == take_view(root_history).index_of_repetition(board.ue.hash, true));
 }
 
 TEST_CASE("Repetition checking in search"){
@@ -50,39 +52,39 @@ TEST_CASE("Repetition checking in search"){
 	parse_fen("8/1p6/1P5p/3Rr2k/p3r1q1/3Q2P1/5B2/6K1 b - - 3 49", board);
 	History root_history;
 	HistoryView search_history = take_view(root_history);
-	CHECK(-1 == search_history.index_of_repetition(board.ue.hash));
+	CHECK(-1 == search_history.index_of_repetition(board.ue.hash, true));
 
 	search_history = search_history.extend(board.ue.hash);
 	make_move<false>(board, move_from_squares(G4, F5, QUEEN_MOVE));
-	CHECK(-1 == search_history.index_of_repetition(board.ue.hash));
+	CHECK(-1 == search_history.index_of_repetition(board.ue.hash, true));
 
 	search_history = search_history.extend(board.ue.hash);
 	make_move<true>(board, move_from_squares(D3, D1, QUEEN_MOVE));
-	CHECK(-1 == search_history.index_of_repetition(board.ue.hash));
+	CHECK(-1 == search_history.index_of_repetition(board.ue.hash, true));
 
 	search_history = search_history.extend(board.ue.hash);
 	make_move<false>(board, move_from_squares(F5, G4, QUEEN_MOVE));
-	CHECK(-1 == search_history.index_of_repetition(board.ue.hash));
+	CHECK(-1 == search_history.index_of_repetition(board.ue.hash, true));
 
 	search_history = search_history.extend(board.ue.hash);
 	make_move<true>(board, move_from_squares(D1, D3, QUEEN_MOVE));
 	// Two-fold which we identify as a draw in search
-	CHECK(0 == search_history.index_of_repetition(board.ue.hash));
+	CHECK(0 == search_history.index_of_repetition(board.ue.hash, false));
 
 	search_history = search_history.extend(board.ue.hash);
 	make_move<false>(board, move_from_squares(E5, F5, ROOK_MOVE));
-	CHECK(-1 == search_history.index_of_repetition(board.ue.hash));
+	CHECK(-1 == search_history.index_of_repetition(board.ue.hash, true));
 
 	search_history = search_history.extend(board.ue.hash);
 	make_move<true>(board, move_from_squares(G1, F1, KING_MOVE));
-	CHECK(-1 == search_history.index_of_repetition(board.ue.hash));
+	CHECK(-1 == search_history.index_of_repetition(board.ue.hash, true));
 
 	search_history = search_history.extend(board.ue.hash);
 	make_move<false>(board, move_from_squares(F5, E5, ROOK_MOVE));
-	CHECK(-1 == search_history.index_of_repetition(board.ue.hash));
+	CHECK(-1 == search_history.index_of_repetition(board.ue.hash, true));
 
 	search_history = search_history.extend(board.ue.hash);
 	make_move<true>(board, move_from_squares(F1, G1, KING_MOVE));
 	// Threefold. When searching for repetition, we first find the one at ply 4
-	CHECK(4 == search_history.index_of_repetition(board.ue.hash));
+	CHECK(4 == search_history.index_of_repetition(board.ue.hash, false));
 }


### PR DESCRIPTION
- Avoid copying of history arrays, resulting in a 5% speedup
- Divide evaluation by two for lines without a pawn move or capture after 20 plies without progress
- Add ply count to hash key within 10 plies of the 50-move rule to avoid blunders near the boundary

This shouldn't have a major effect on ELO (it gained ~5 in a test). The main motivation here is faster self play data generation and avoiding 50-move rule draws in positions with a huge advantage.